### PR TITLE
Refactor landing page into ad-friendly HTML directory layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noai" />
+    <meta
+      name="description"
+      content="AI Porn Direct is a monetization-ready HTML directory of the best AI adult apps, generators, and creator tools."
+    />
     <title>AI Porn Direct</title>
     <link rel="stylesheet" href="styles.css" />
     <script defer src="script.js"></script>
@@ -26,13 +30,32 @@
       </div>
     </div>
 
-    <header class="hero">
+    <header class="site-header" role="banner">
+      <div class="site-header-inner">
+        <a class="logo" href="#top">AI Porn Direct</a>
+        <nav class="main-nav" aria-label="Primary">
+          <a href="#directory">Directory</a>
+          <a href="#categories">Categories</a>
+          <a href="#guides">Resources</a>
+          <a href="#newsletter">Newsletter</a>
+          <a href="#advertise">Advertise</a>
+        </nav>
+      </div>
+    </header>
+
+    <div class="ad-slot leaderboard" aria-label="Leaderboard advertising slot">
+      <span>Leaderboard 970×250 — Reserve premium inventory</span>
+    </div>
+
+    <header class="hero" id="top">
       <div class="hero-inner">
         <span class="hero-badge">18+ Verified Directory</span>
         <h1>AI Porn Direct</h1>
         <p class="subtitle">
-          Discover trusted AI image, video, voice, chat, and automation tools
-          for adult creators.
+          Monetize adult audiences with the most trusted catalog of AI porn
+          generators, chat companions, voice clones, and creator automations.
+          Every link is optimized for affiliate tracking and high-intent ad
+          revenue.
         </p>
         <div class="hero-stats" role="list">
           <article class="stat-card" role="listitem">
@@ -41,7 +64,7 @@
           </article>
           <article class="stat-card" role="listitem">
             <span class="stat-value" id="stat-free">0</span>
-            <span class="stat-label">Free & freemium</span>
+            <span class="stat-label">Free &amp; freemium</span>
           </article>
           <article class="stat-card" role="listitem">
             <span class="stat-value" id="stat-updated">—</span>
@@ -52,57 +75,218 @@
           <button class="btn" id="browse-all" type="button">
             Browse the directory
           </button>
+          <a class="btn ghost" href="#advertise">Media kit</a>
           <a class="btn ghost" href="#newsletter">Get updates</a>
         </div>
+        <ul class="hero-highlights">
+          <li>Affiliate-ready links, payouts, and promo notes in every profile.</li>
+          <li>SEO-focused, static HTML architecture built for fast ad delivery.</li>
+          <li>Weekly curations across image, video, chat, voice, and automation.</li>
+        </ul>
+        <p class="hero-note">We may earn commissions from partners we list.</p>
       </div>
     </header>
 
-    <section
-      class="category-board"
-      id="category-board"
-      aria-label="Browse by category"
-    ></section>
-
-    <section class="controls" aria-label="Directory filters">
-      <input
-        type="search"
-        id="q"
-        placeholder="Search tools..."
-        aria-label="Search"
-        data-testid="search-input"
-      />
-      <select
-        id="category"
-        aria-label="Category"
-        data-testid="select-category"
-      ></select>
-      <select id="pricing" aria-label="Pricing" data-testid="select-pricing">
-        <option value="">All pricing</option>
-        <option value="free">Free</option>
-        <option value="freemium">Freemium</option>
-        <option value="paid">Paid</option>
-      </select>
-      <select id="sort" aria-label="Sort" data-testid="select-sort">
-        <option value="score-desc">Top rated</option>
-        <option value="pop-desc">Most popular</option>
-        <option value="alpha-asc">A to Z</option>
-        <option value="alpha-desc">Z to A</option>
-        <option value="newest">Newest</option>
-      </select>
+    <section class="intro">
+      <div class="intro-inner">
+        <div class="intro-copy">
+          <h2>HTML-first, monetization-focused directory</h2>
+          <p>
+            AI Porn Direct is intentionally lightweight: pure HTML, CSS, and a
+            single script to hydrate the listings. That keeps Core Web Vitals in
+            the green, lets ad networks approve faster, and delivers affiliate
+            clicks with minimal friction.
+          </p>
+        </div>
+        <div class="intro-grid" role="list">
+          <article class="info-card" role="listitem">
+            <h3>Ad inventory ready</h3>
+            <p>
+              Drop in leaderboard, rectangle, or skyscraper creative without
+              redesigning the layout.
+            </p>
+          </article>
+          <article class="info-card" role="listitem">
+            <h3>Affiliate friendly</h3>
+            <p>
+              Every outbound link can include tracking IDs and disclosure text to
+              keep compliance tight.
+            </p>
+          </article>
+          <article class="info-card" role="listitem">
+            <h3>Always updated</h3>
+            <p>
+              A structured JSON database powers filters, featured picks, and
+              search without heavy infrastructure.
+            </p>
+          </article>
+        </div>
+      </div>
     </section>
 
-    <section
-      id="featured"
-      class="featured-section"
-      aria-label="Featured tools"
-    ></section>
-    <section
-      id="trending"
-      class="trending-section"
-      aria-label="Trending now"
-    ></section>
+    <section id="directory" class="directory">
+      <div class="directory-inner">
+        <div class="directory-heading">
+          <h2>Browse the best AI adult products</h2>
+          <p>
+            Use the filters to surface high-performing partners for your traffic
+            niches, from creator marketplaces to voiceover SaaS.
+          </p>
+        </div>
+        <div class="directory-layout">
+          <div class="directory-main">
+            <section id="categories" class="directory-section">
+              <div
+                id="category-board"
+                class="category-board"
+                aria-label="Browse by category"
+              ></div>
+            </section>
 
-    <main id="grid" data-testid="grid" aria-live="polite"></main>
+            <section class="directory-controls" aria-label="Directory filters">
+              <div class="section-header">
+                <h3>Filter the database</h3>
+                <p>Search, refine by category or pricing, and sort by intent.</p>
+              </div>
+              <div class="controls">
+                <input
+                  type="search"
+                  id="q"
+                  placeholder="Search tools..."
+                  aria-label="Search"
+                  data-testid="search-input"
+                />
+                <select
+                  id="category"
+                  aria-label="Category"
+                  data-testid="select-category"
+                ></select>
+                <select
+                  id="pricing"
+                  aria-label="Pricing"
+                  data-testid="select-pricing"
+                >
+                  <option value="">All pricing</option>
+                  <option value="free">Free</option>
+                  <option value="freemium">Freemium</option>
+                  <option value="paid">Paid</option>
+                </select>
+                <select id="sort" aria-label="Sort" data-testid="select-sort">
+                  <option value="score-desc">Top rated</option>
+                  <option value="pop-desc">Most popular</option>
+                  <option value="alpha-asc">A to Z</option>
+                  <option value="alpha-desc">Z to A</option>
+                  <option value="newest">Newest</option>
+                </select>
+              </div>
+            </section>
+
+            <div class="ad-slot inline-ad" aria-label="Inline advertising slot">
+              <span>Feature your launch — 728×90 banner placement available</span>
+            </div>
+
+            <section
+              id="featured"
+              class="featured-section"
+              aria-label="Featured tools"
+            ></section>
+            <section
+              id="trending"
+              class="trending-section"
+              aria-label="Trending now"
+            ></section>
+
+            <main id="grid" data-testid="grid" aria-live="polite"></main>
+            <script type="application/ld+json" id="ld-itemlist"></script>
+          </div>
+
+          <aside class="directory-sidebar" aria-label="Monetization options">
+            <div class="ad-slot skyscraper">
+              <span>Skyscraper 300×600 — Own the prime sidebar real estate</span>
+            </div>
+            <div class="sidebar-card">
+              <h3>Submit a tool</h3>
+              <p>
+                Have an AI adult product to feature? Pitch it and include your
+                affiliate program details.
+              </p>
+              <a class="btn ghost" href="mailto:listings@aiporndirect.com"
+                >List your product</a
+              >
+            </div>
+            <div class="sidebar-card">
+              <h3>Advertise with us</h3>
+              <p>
+                Unlock featured placement, newsletter shoutouts, and sponsored
+                reviews tailored to adult traffic.
+              </p>
+              <a class="btn" href="mailto:ads@aiporndirect.com"
+                >Request media kit</a
+              >
+            </div>
+            <div class="ad-slot rectangle">
+              <span>Medium rectangle 300×250 — Affiliate spotlight</span>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section id="guides" class="content-block">
+      <div class="content-inner">
+        <div class="section-header">
+          <h2>What makes the cut</h2>
+          <p>
+            We vet every listing for real payouts, community feedback, and clear
+            compliance policies before it hits the directory.
+          </p>
+        </div>
+        <div class="content-grid">
+          <article class="content-card">
+            <h3>Signals we monitor</h3>
+            <ul>
+              <li>Conversion data and EPC benchmarks from creator affiliates.</li>
+              <li>Feature velocity and roadmap transparency from product teams.</li>
+              <li>Community sentiment across Reddit, Twitter, and creator forums.</li>
+            </ul>
+          </article>
+          <article class="content-card">
+            <h3>Listing enhancements</h3>
+            <ul>
+              <li>Custom copy tuned for adult SEO keywords and fan intent.</li>
+              <li>Structured data and filters to keep traffic engaged longer.</li>
+              <li>Optional promo codes, assets, and creatives from partners.</li>
+            </ul>
+          </article>
+          <article class="content-card">
+            <h3>Future roadmap</h3>
+            <ul>
+              <li>Regional landing pages for UK, EU, LATAM, and APAC audiences.</li>
+              <li>Programmatic featured slots with transparent pricing.</li>
+              <li>Quarterly deep dives into retention, ARPU, and churn trends.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="advertise" class="cta-banner">
+      <div class="cta-inner">
+        <div class="cta-copy">
+          <h2>Partner with AI Porn Direct</h2>
+          <p>
+            Run ads, sponsor content, or syndicate your affiliate program across
+            a curated network of adult traffic partners.
+          </p>
+        </div>
+        <div class="cta-actions">
+          <a class="btn" href="mailto:ads@aiporndirect.com">Book a campaign</a>
+          <a class="btn ghost" href="mailto:tips@aiporndirect.com"
+            >Submit news</a
+          >
+        </div>
+      </div>
+    </section>
 
     <section id="newsletter" class="newsletter">
       <div class="newsletter-inner">
@@ -132,18 +316,28 @@
       </div>
     </section>
 
-    <script type="application/ld+json" id="ld-itemlist"></script>
-
     <footer>
-      <p>
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <strong>AI Porn Direct</strong>
+          <p>
+            A fast, HTML-based index of the best AI adult tools. Curated for
+            affiliate marketers, creators, and media buyers.
+          </p>
+        </div>
+        <nav class="footer-nav" aria-label="Footer navigation">
+          <a href="#directory">Directory</a>
+          <a href="#guides">Resources</a>
+          <a href="#advertise">Advertise</a>
+          <a href="mailto:listings@aiporndirect.com">Submit listing</a>
+          <a href="privacy.txt">Privacy</a>
+          <a href="terms.txt">Terms</a>
+        </nav>
+      </div>
+      <p class="footer-disclaimer">
         18+ disclaimer. No illegal content. No minors. We link to third-party
-        tools only.
+        tools only and may receive affiliate compensation.
       </p>
-      <p>We may earn commissions from links.</p>
-      <nav>
-        <a href="privacy.txt">Privacy</a>
-        <a href="terms.txt">Terms</a>
-      </nav>
     </footer>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,89 @@ footer {
   width: 100%;
 }
 
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  background: rgba(7, 7, 9, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.site-header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+}
+
+.main-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.main-nav a {
+  text-decoration: none;
+  color: var(--muted);
+  transition: color 0.2s ease;
+}
+
+.main-nav a:hover,
+.main-nav a:focus-visible {
+  color: var(--accent);
+}
+
+.ad-slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(15, 15, 25, 0.6);
+  border: 1px dashed rgba(255, 255, 255, 0.25);
+  border-radius: calc(var(--radius) + 4px);
+  padding: 1.5rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  box-shadow: inset 0 0 0 1px rgba(255, 79, 154, 0.1);
+}
+
+.ad-slot span {
+  max-width: 460px;
+}
+
+.leaderboard {
+  max-width: 1100px;
+  margin: 1.5rem auto 0;
+  min-height: 140px;
+}
+
+.inline-ad {
+  min-height: 120px;
+}
+
+.skyscraper {
+  min-height: 320px;
+}
+
+.rectangle {
+  min-height: 160px;
+}
+
 .hero {
   padding: 4rem 1.5rem 3rem;
 }
@@ -184,17 +267,153 @@ footer {
   color: var(--accent);
 }
 
-.category-board {
+.hero-highlights {
+  margin: 2rem 0 1rem;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.hero-highlights li {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero-highlights li::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: 0.45rem;
+}
+
+.hero-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.intro {
+  padding: 3rem 1.5rem 1rem;
+}
+
+.intro-inner {
   max-width: 1100px;
   margin: 0 auto;
-  padding: 0 1.5rem 3rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.intro-copy {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.intro-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.info-card {
+  background: rgba(15, 15, 25, 0.7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.6rem 1.5rem;
+  display: grid;
+  gap: 0.65rem;
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.25);
+}
+
+.info-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.directory {
+  padding: 3rem 1.5rem 4rem;
+}
+
+.directory-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.directory-heading {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 720px;
+}
+
+.directory-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  align-items: start;
+}
+
+.directory-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.directory-controls {
+  background: rgba(15, 15, 25, 0.72);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) + 4px);
+  padding: 1.8rem;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
+}
+
+.directory-controls .controls {
+  padding: 0;
+  margin: 0;
+}
+
+.directory-controls .section-header {
+  margin-bottom: 1.5rem;
+}
+
+.directory-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: sticky;
+  top: 6rem;
+}
+
+.sidebar-card {
+  background: rgba(15, 15, 25, 0.8);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.8rem 1.6rem;
+  display: grid;
+  gap: 0.8rem;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.28);
+}
+
+.sidebar-card h3 {
+  margin: 0;
+}
+
+.category-board {
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
 }
 
 .category-header {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  margin-bottom: 1.5rem;
 }
 
 .category-header h2 {
@@ -262,9 +481,6 @@ footer {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  padding: 0 1.5rem 2.5rem;
-  max-width: 1100px;
-  margin: 0 auto;
 }
 
 .controls input,
@@ -310,9 +526,7 @@ footer {
 }
 
 .featured-section {
-  max-width: 1100px;
-  margin: 0 auto 2.5rem;
-  padding: 0 1.5rem;
+  width: 100%;
 }
 
 .featured-grid {
@@ -363,9 +577,7 @@ footer {
 }
 
 .trending-section {
-  max-width: 1100px;
-  margin: 0 auto 2.5rem;
-  padding: 0 1.5rem;
+  width: 100%;
 }
 
 .trending-grid {
@@ -414,9 +626,6 @@ main#grid {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  padding: 0 1.5rem 3.5rem;
-  max-width: 1100px;
-  margin: 0 auto;
 }
 
 .card {
@@ -521,58 +730,40 @@ main#grid {
 
 .card-feature-list li::before {
   content: "";
-  width: 0.45rem;
-  height: 0.45rem;
+  display: inline-block;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--accent);
-  opacity: 0.8;
 }
 
 .card-actions {
-  margin-top: auto;
+  display: flex;
+  gap: 0.75rem;
 }
 
 .card-actions a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  background: var(--accent);
-  color: #fff;
   text-decoration: none;
-  padding: 0.85rem 1rem;
-  border-radius: var(--radius);
+  color: var(--accent);
   font-weight: 600;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
 }
 
 .card-actions a:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(255, 79, 154, 0.35);
+  text-decoration: underline;
 }
 
 .empty-state {
-  grid-column: 1 / -1;
   text-align: center;
-  background: var(--bg-panel);
+  background: rgba(15, 15, 25, 0.7);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 2.5rem 1.5rem;
-}
-
-.empty-state h3 {
-  margin: 0 0 0.5rem;
+  padding: 3rem 1.5rem;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 0.75rem;
 }
 
 .newsletter {
-  background: linear-gradient(
-    160deg,
-    rgba(255, 79, 154, 0.16),
-    rgba(17, 17, 25, 0.82)
-  );
-  margin: 0;
   padding: 3.5rem 1.5rem;
 }
 
@@ -619,27 +810,116 @@ main#grid {
   color: var(--muted);
 }
 
+.content-block {
+  padding: 3.5rem 1.5rem;
+}
+
+.content-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.content-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.content-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.75rem 1.6rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
+}
+
+.content-card h3 {
+  margin: 0;
+}
+
+.content-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.cta-banner {
+  padding: 3.5rem 1.5rem;
+  background: linear-gradient(120deg, rgba(255, 79, 154, 0.25), rgba(24, 24, 35, 0.85));
+  border-block: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cta-inner {
+  max-width: 1050px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cta-copy {
+  max-width: 520px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 footer {
   border-top: 1px solid var(--border);
-  padding: 2.5rem 1.5rem;
-  text-align: center;
+  padding: 3rem 1.5rem 2rem;
+  background: rgba(15, 15, 25, 0.6);
   color: var(--muted);
 }
 
-footer nav {
-  margin-top: 1.2rem;
+.footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
   display: flex;
-  justify-content: center;
-  gap: 1.75rem;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+  align-items: flex-start;
+  justify-content: space-between;
 }
 
-footer a {
+.footer-brand {
+  max-width: 360px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.footer-nav {
+  display: grid;
+  gap: 0.65rem 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.footer-nav a {
   color: var(--text);
   text-decoration: none;
+  font-size: 0.95rem;
 }
 
-footer a:hover {
+.footer-nav a:hover {
   text-decoration: underline;
+}
+
+.footer-disclaimer {
+  max-width: 1100px;
+  margin: 2rem auto 0;
+  text-align: center;
 }
 
 .modal {
@@ -684,6 +964,33 @@ footer a:hover {
   border: 0;
 }
 
+@media (max-width: 960px) {
+  .site-header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .main-nav {
+    width: 100%;
+    gap: 1rem;
+  }
+
+  .directory-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .directory-sidebar {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .directory-sidebar > * {
+    flex: 1 1 280px;
+  }
+}
+
 @media (max-width: 720px) {
   .hero-inner {
     padding: 2.2rem;
@@ -695,5 +1002,28 @@ footer a:hover {
 
   .card {
     padding: 1.4rem 1.2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-highlights {
+    gap: 0.65rem;
+  }
+
+  .intro {
+    padding-top: 2.5rem;
+  }
+
+  .leaderboard {
+    margin: 1rem 1.5rem 0;
+  }
+
+  .cta-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .footer-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- rebuild index.html into a static HTML-first landing page with navigation, ad slots, and affiliate messaging
- expand styles.css with layout, sidebar, and content sections tailored for monetization and directory browsing
- add resource, advertising, and newsletter sections to support ad revenue and affiliate program goals

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d320d0942083318759bb579db3ffc7