### PR TITLE
Redesign directory with mobile-first styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="noai" />
     <meta
       name="description"
-      content="AI Porn Direct is a monetization-ready HTML directory of the best AI adult apps, generators, and creator tools."
+      content="AI Porn Direct is a beautiful, mobile-first directory of the best AI adult apps, generators, and creator tools."
     />
     <title>AI Porn Direct</title>
     <link rel="stylesheet" href="styles.css" />
@@ -24,320 +24,181 @@
         <h2 id="age-gate-title">18+ confirmation</h2>
         <p>You must be 18 years or older to enter this site.</p>
         <div class="modal-actions">
-          <button id="age-enter">Enter</button>
-          <button id="age-leave">Leave</button>
+          <button id="age-enter" class="btn">Enter</button>
+          <button id="age-leave" class="btn ghost">Leave</button>
         </div>
       </div>
     </div>
 
-    <header class="site-header" role="banner">
-      <div class="site-header-inner">
-        <a class="logo" href="#top">AI Porn Direct</a>
-        <nav class="main-nav" aria-label="Primary">
+    <header class="topbar" role="banner">
+      <div class="container topbar__inner">
+        <a class="brand" href="#top">AI Porn Direct</a>
+        <nav class="topbar__nav" aria-label="Primary">
           <a href="#directory">Directory</a>
-          <a href="#categories">Categories</a>
-          <a href="#guides">Resources</a>
-          <a href="#newsletter">Newsletter</a>
-          <a href="#advertise">Advertise</a>
+          <a href="#newsletter">Updates</a>
+          <a href="mailto:ads@aiporndirect.com">Advertise</a>
         </nav>
       </div>
     </header>
 
-    <div class="ad-slot leaderboard" aria-label="Leaderboard advertising slot">
-      <span>Leaderboard 970×250 — Reserve premium inventory</span>
-    </div>
-
-    <header class="hero" id="top">
-      <div class="hero-inner">
-        <span class="hero-badge">18+ Verified Directory</span>
-        <h1>AI Porn Direct</h1>
-        <p class="subtitle">
-          Monetize adult audiences with the most trusted catalog of AI porn
-          generators, chat companions, voice clones, and creator automations.
-          Every link is optimized for affiliate tracking and high-intent ad
-          revenue.
-        </p>
-        <div class="hero-stats" role="list">
-          <article class="stat-card" role="listitem">
-            <span class="stat-value" id="stat-total">0</span>
-            <span class="stat-label">Tools listed</span>
-          </article>
-          <article class="stat-card" role="listitem">
-            <span class="stat-value" id="stat-free">0</span>
-            <span class="stat-label">Free &amp; freemium</span>
-          </article>
-          <article class="stat-card" role="listitem">
-            <span class="stat-value" id="stat-updated">—</span>
-            <span class="stat-label">Last update</span>
-          </article>
-        </div>
-        <div class="hero-actions">
-          <button class="btn" id="browse-all" type="button">
-            Browse the directory
-          </button>
-          <a class="btn ghost" href="#advertise">Media kit</a>
-          <a class="btn ghost" href="#newsletter">Get updates</a>
-        </div>
-        <ul class="hero-highlights">
-          <li>Affiliate-ready links, payouts, and promo notes in every profile.</li>
-          <li>SEO-focused, static HTML architecture built for fast ad delivery.</li>
-          <li>Weekly curations across image, video, chat, voice, and automation.</li>
-        </ul>
-        <p class="hero-note">We may earn commissions from partners we list.</p>
-      </div>
-    </header>
-
-    <section class="intro">
-      <div class="intro-inner">
-        <div class="intro-copy">
-          <h2>HTML-first, monetization-focused directory</h2>
-          <p>
-            AI Porn Direct is intentionally lightweight: pure HTML, CSS, and a
-            single script to hydrate the listings. That keeps Core Web Vitals in
-            the green, lets ad networks approve faster, and delivers affiliate
-            clicks with minimal friction.
+    <main>
+      <section class="hero" id="top">
+        <div class="container hero__inner">
+          <span class="hero-badge">Curated AI adult tools</span>
+          <h1>Discover the top AI porn apps</h1>
+          <p class="subtitle">
+            A hand-picked, mobile-ready index for adult creators, affiliates, and media buyers. Fast loads, clear rankings, and links that actually convert.
           </p>
-        </div>
-        <div class="intro-grid" role="list">
-          <article class="info-card" role="listitem">
-            <h3>Ad inventory ready</h3>
-            <p>
-              Drop in leaderboard, rectangle, or skyscraper creative without
-              redesigning the layout.
-            </p>
-          </article>
-          <article class="info-card" role="listitem">
-            <h3>Affiliate friendly</h3>
-            <p>
-              Every outbound link can include tracking IDs and disclosure text to
-              keep compliance tight.
-            </p>
-          </article>
-          <article class="info-card" role="listitem">
-            <h3>Always updated</h3>
-            <p>
-              A structured JSON database powers filters, featured picks, and
-              search without heavy infrastructure.
-            </p>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section id="directory" class="directory">
-      <div class="directory-inner">
-        <div class="directory-heading">
-          <h2>Browse the best AI adult products</h2>
-          <p>
-            Use the filters to surface high-performing partners for your traffic
-            niches, from creator marketplaces to voiceover SaaS.
-          </p>
-        </div>
-        <div class="directory-layout">
-          <div class="directory-main">
-            <section id="categories" class="directory-section">
-              <div
-                id="category-board"
-                class="category-board"
-                aria-label="Browse by category"
-              ></div>
-            </section>
-
-            <section class="directory-controls" aria-label="Directory filters">
-              <div class="section-header">
-                <h3>Filter the database</h3>
-                <p>Search, refine by category or pricing, and sort by intent.</p>
-              </div>
-              <div class="controls">
-                <input
-                  type="search"
-                  id="q"
-                  placeholder="Search tools..."
-                  aria-label="Search"
-                  data-testid="search-input"
-                />
-                <select
-                  id="category"
-                  aria-label="Category"
-                  data-testid="select-category"
-                ></select>
-                <select
-                  id="pricing"
-                  aria-label="Pricing"
-                  data-testid="select-pricing"
-                >
-                  <option value="">All pricing</option>
-                  <option value="free">Free</option>
-                  <option value="freemium">Freemium</option>
-                  <option value="paid">Paid</option>
-                </select>
-                <select id="sort" aria-label="Sort" data-testid="select-sort">
-                  <option value="score-desc">Top rated</option>
-                  <option value="pop-desc">Most popular</option>
-                  <option value="alpha-asc">A to Z</option>
-                  <option value="alpha-desc">Z to A</option>
-                  <option value="newest">Newest</option>
-                </select>
-              </div>
-            </section>
-
-            <div class="ad-slot inline-ad" aria-label="Inline advertising slot">
-              <span>Feature your launch — 728×90 banner placement available</span>
-            </div>
-
-            <section
-              id="featured"
-              class="featured-section"
-              aria-label="Featured tools"
-            ></section>
-            <section
-              id="trending"
-              class="trending-section"
-              aria-label="Trending now"
-            ></section>
-
-            <main id="grid" data-testid="grid" aria-live="polite"></main>
-            <script type="application/ld+json" id="ld-itemlist"></script>
+          <div class="hero-actions">
+            <button class="btn" id="browse-all" type="button">Browse directory</button>
+            <a class="btn ghost" href="#advertise">Media kit</a>
+            <a class="btn ghost" href="#newsletter">Get updates</a>
           </div>
-
-          <aside class="directory-sidebar" aria-label="Monetization options">
-            <div class="ad-slot skyscraper">
-              <span>Skyscraper 300×600 — Own the prime sidebar real estate</span>
-            </div>
-            <div class="sidebar-card">
-              <h3>Submit a tool</h3>
-              <p>
-                Have an AI adult product to feature? Pitch it and include your
-                affiliate program details.
-              </p>
-              <a class="btn ghost" href="mailto:listings@aiporndirect.com"
-                >List your product</a
-              >
-            </div>
-            <div class="sidebar-card">
-              <h3>Advertise with us</h3>
-              <p>
-                Unlock featured placement, newsletter shoutouts, and sponsored
-                reviews tailored to adult traffic.
-              </p>
-              <a class="btn" href="mailto:ads@aiporndirect.com"
-                >Request media kit</a
-              >
-            </div>
-            <div class="ad-slot rectangle">
-              <span>Medium rectangle 300×250 — Affiliate spotlight</span>
-            </div>
-          </aside>
+          <div class="hero-stats" role="list">
+            <article class="stat-card" role="listitem">
+              <span class="stat-value" id="stat-total">0</span>
+              <span class="stat-label">Tools listed</span>
+            </article>
+            <article class="stat-card" role="listitem">
+              <span class="stat-value" id="stat-free">0</span>
+              <span class="stat-label">Free &amp; freemium</span>
+            </article>
+            <article class="stat-card" role="listitem">
+              <span class="stat-value" id="stat-updated">—</span>
+              <span class="stat-label">Last update</span>
+            </article>
+          </div>
+          <ul class="hero-highlights">
+            <li>Ranked listings with pricing, traffic estimates, and must-know perks.</li>
+            <li>Optimized for phones with thumb-friendly filters and sticky CTAs.</li>
+            <li>Affiliate-ready copy, compliance notes, and promo tips on every card.</li>
+          </ul>
+          <p class="hero-note">We may earn commissions from partners we list.</p>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section id="guides" class="content-block">
-      <div class="content-inner">
-        <div class="section-header">
-          <h2>What makes the cut</h2>
-          <p>
-            We vet every listing for real payouts, community feedback, and clear
-            compliance policies before it hits the directory.
-          </p>
+      <section class="section intro">
+        <div class="container intro__inner">
+          <div class="section-header">
+            <h2>Built for scrolling, not bloated landing pages</h2>
+            <p>
+              AI Porn Direct is a single, responsive page tuned for speed. Static HTML, progressive enhancement, and one JSON feed keep Core Web Vitals in the green while your ad stack stays fast.
+            </p>
+          </div>
+          <div class="intro-grid" role="list">
+            <article class="info-card" role="listitem">
+              <h3>Made for mobile</h3>
+              <p>Cards snap into a clean vertical feed with generous tap targets and big typography.</p>
+            </article>
+            <article class="info-card" role="listitem">
+              <h3>Affiliate friendly</h3>
+              <p>Drop in tracking IDs, disclosure labels, and promo notes without touching the layout.</p>
+            </article>
+            <article class="info-card" role="listitem">
+              <h3>Ad inventory ready</h3>
+              <p>Leaderboard, rectangle, and native placements are mapped with flexible house slots.</p>
+            </article>
+          </div>
         </div>
-        <div class="content-grid">
-          <article class="content-card">
-            <h3>Signals we monitor</h3>
-            <ul>
-              <li>Conversion data and EPC benchmarks from creator affiliates.</li>
-              <li>Feature velocity and roadmap transparency from product teams.</li>
-              <li>Community sentiment across Reddit, Twitter, and creator forums.</li>
-            </ul>
-          </article>
-          <article class="content-card">
-            <h3>Listing enhancements</h3>
-            <ul>
-              <li>Custom copy tuned for adult SEO keywords and fan intent.</li>
-              <li>Structured data and filters to keep traffic engaged longer.</li>
-              <li>Optional promo codes, assets, and creatives from partners.</li>
-            </ul>
-          </article>
-          <article class="content-card">
-            <h3>Future roadmap</h3>
-            <ul>
-              <li>Regional landing pages for UK, EU, LATAM, and APAC audiences.</li>
-              <li>Programmatic featured slots with transparent pricing.</li>
-              <li>Quarterly deep dives into retention, ARPU, and churn trends.</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
+      </section>
 
-    <section id="advertise" class="cta-banner">
-      <div class="cta-inner">
-        <div class="cta-copy">
-          <h2>Partner with AI Porn Direct</h2>
-          <p>
-            Run ads, sponsor content, or syndicate your affiliate program across
-            a curated network of adult traffic partners.
-          </p>
-        </div>
-        <div class="cta-actions">
-          <a class="btn" href="mailto:ads@aiporndirect.com">Book a campaign</a>
-          <a class="btn ghost" href="mailto:tips@aiporndirect.com"
-            >Submit news</a
-          >
-        </div>
-      </div>
-    </section>
+      <section class="section">
+        <div class="container" id="featured" aria-live="polite"></div>
+      </section>
 
-    <section id="newsletter" class="newsletter">
-      <div class="newsletter-inner">
-        <h2>Stay in the loop</h2>
-        <p>
-          Get monthly roundups of new AI adult tools, no spam, unsubscribe
-          anytime.
-        </p>
-        <form
-          class="newsletter-form"
-          action="https://example.com"
-          method="post"
-        >
-          <label class="sr-only" for="email">Email address</label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            placeholder="you@example.com"
-            required
-          />
-          <button type="submit" class="btn">Notify me</button>
-        </form>
-        <small
-          >No explicit content. Just product updates and launch alerts.</small
-        >
-      </div>
-    </section>
+      <section id="directory" class="section directory">
+        <div class="container directory__inner">
+          <div class="section-header">
+            <h2>Explore the directory</h2>
+            <p>Filter by keyword, pricing, or niche to surface the AI porn generators worth your traffic.</p>
+          </div>
+          <form class="filter-panel" role="search">
+            <label class="sr-only" for="q">Search listings</label>
+            <input id="q" name="q" type="search" placeholder="Search tools" />
+            <label class="sr-only" for="category">Filter by category</label>
+            <select id="category" name="category">
+              <option value="">All categories</option>
+            </select>
+            <label class="sr-only" for="pricing">Filter by pricing</label>
+            <select id="pricing" name="pricing">
+              <option value="">All pricing</option>
+              <option value="free">Free</option>
+              <option value="freemium">Freemium</option>
+              <option value="paid">Paid</option>
+            </select>
+            <label class="sr-only" for="sort">Sort results</label>
+            <select id="sort" name="sort">
+              <option value="score-desc">Editor score</option>
+              <option value="pop-desc">Most popular</option>
+              <option value="alpha-asc">A → Z</option>
+              <option value="alpha-desc">Z → A</option>
+              <option value="newest">Newest</option>
+            </select>
+          </form>
+          <div id="category-board" class="category-board" aria-live="polite"></div>
+          <div class="house-slot" role="complementary">
+            <span>Leaderboard 970×250 — Premium placement available</span>
+          </div>
+          <div id="grid" class="card-grid" aria-live="polite"></div>
+        </div>
+      </section>
 
-    <footer>
-      <div class="footer-inner">
+      <section class="section">
+        <div class="container" id="trending" aria-live="polite"></div>
+      </section>
+
+      <section id="advertise" class="section advertise">
+        <div class="container advertise__inner">
+          <div class="section-header">
+            <h2>Partner with AI Porn Direct</h2>
+            <p>Sponsored placements, newsletter drops, and native reviews built for adult traffic.</p>
+          </div>
+          <div class="advertise-actions">
+            <a class="btn" href="mailto:ads@aiporndirect.com">Request media kit</a>
+            <a class="btn ghost" href="mailto:listings@aiporndirect.com">Submit a tool</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="newsletter" class="section newsletter">
+        <div class="container newsletter__inner">
+          <h2>Stay in the loop</h2>
+          <p>Monthly roundups of new AI adult tools. No spam, unsubscribe anytime.</p>
+          <form class="newsletter-form" action="https://example.com" method="post">
+            <label class="sr-only" for="email">Email address</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              placeholder="you@example.com"
+              required
+            />
+            <button type="submit" class="btn">Notify me</button>
+          </form>
+          <small>No explicit content. Just product updates and launch alerts.</small>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container footer__inner">
         <div class="footer-brand">
           <strong>AI Porn Direct</strong>
-          <p>
-            A fast, HTML-based index of the best AI adult tools. Curated for
-            affiliate marketers, creators, and media buyers.
-          </p>
+          <p>A fast, HTML-based index of the best AI adult tools for affiliates and creators.</p>
         </div>
-        <nav class="footer-nav" aria-label="Footer navigation">
+        <nav class="footer-nav" aria-label="Footer">
           <a href="#directory">Directory</a>
-          <a href="#guides">Resources</a>
           <a href="#advertise">Advertise</a>
-          <a href="mailto:listings@aiporndirect.com">Submit listing</a>
+          <a href="mailto:tips@aiporndirect.com">Submit news</a>
           <a href="privacy.txt">Privacy</a>
           <a href="terms.txt">Terms</a>
         </nav>
       </div>
       <p class="footer-disclaimer">
-        18+ disclaimer. No illegal content. No minors. We link to third-party
-        tools only and may receive affiliate compensation.
+        18+ disclaimer. No illegal content. No minors. We link to third-party tools only and may receive affiliate compensation.
       </p>
     </footer>
+
+    <script id="ld-itemlist" type="application/ld+json"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,22 @@
 :root {
   color-scheme: dark;
-  --bg: #070709;
-  --bg-panel: #12121a;
-  --bg-card: #181823;
-  --bg-soft: rgba(255, 79, 154, 0.08);
-  --text: #f7f7fb;
-  --muted: #a0a0ba;
-  --accent: #ff4f9a;
-  --accent-soft: rgba(255, 79, 154, 0.16);
-  --border: rgba(255, 255, 255, 0.07);
-  --radius: 16px;
-  --shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
-  --glass: rgba(255, 255, 255, 0.04);
+  --bg: #040513;
+  --bg-alt: #090a1d;
+  --surface: rgba(15, 23, 42, 0.65);
+  --surface-strong: rgba(15, 23, 42, 0.85);
+  --card: #f8f9ff;
+  --ink: #0f172a;
+  --muted: #94a3b8;
+  --text: #e2e8f0;
+  --accent: #f97316;
+  --accent-strong: #fb923c;
+  --accent-soft: rgba(249, 115, 22, 0.18);
+  --outline: rgba(148, 163, 255, 0.25);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow: 0 28px 60px rgba(4, 6, 19, 0.55);
+  --shadow-soft: 0 18px 40px rgba(8, 13, 30, 0.35);
 }
 
 * {
@@ -21,6 +26,7 @@
 body {
   margin: 0;
   font-family:
+    "Plus Jakarta Sans",
     "Inter",
     "SF Pro Display",
     -apple-system,
@@ -28,24 +34,23 @@ body {
     "Segoe UI",
     sans-serif;
   background:
-    radial-gradient(
-      circle at 20% -10%,
-      rgba(255, 79, 154, 0.1),
-      transparent 55%
-    ),
-    radial-gradient(
-      circle at 80% 0%,
-      rgba(141, 78, 255, 0.12),
-      transparent 50%
-    ),
-    var(--bg);
+    radial-gradient(circle at 10% -5%, rgba(94, 234, 212, 0.08), transparent 45%),
+    radial-gradient(circle at 85% -10%, rgba(249, 115, 22, 0.12), transparent 50%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-alt) 60%, #05060f 100%);
   color: var(--text);
-  line-height: 1.65;
+  line-height: 1.6;
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--accent-strong);
 }
 
 img {
@@ -53,183 +58,107 @@ img {
   display: block;
 }
 
-header,
-section,
-main,
-footer {
-  width: 100%;
+main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 6vw, 5rem);
 }
 
-.site-header {
+.container {
+  width: min(100%, 1080px);
+  margin: 0 auto;
+  padding: 0 clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.topbar {
   position: sticky;
   top: 0;
   z-index: 20;
-  backdrop-filter: blur(12px);
-  background: rgba(7, 7, 9, 0.85);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(16px);
+  background: rgba(4, 5, 19, 0.78);
+  border-bottom: 1px solid var(--outline);
 }
 
-.site-header-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 1rem 1.5rem;
+.topbar__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  min-height: 72px;
 }
 
-.logo {
+.brand {
   font-weight: 700;
   font-size: 1.1rem;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  text-decoration: none;
 }
 
-.main-nav {
+.topbar__nav {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 1.25rem;
   font-size: 0.95rem;
 }
 
-.main-nav a {
-  text-decoration: none;
+.topbar__nav a {
   color: var(--muted);
-  transition: color 0.2s ease;
-}
-
-.main-nav a:hover,
-.main-nav a:focus-visible {
-  color: var(--accent);
-}
-
-.ad-slot {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  background: rgba(15, 15, 25, 0.6);
-  border: 1px dashed rgba(255, 255, 255, 0.25);
-  border-radius: calc(var(--radius) + 4px);
-  padding: 1.5rem;
-  color: var(--muted);
-  font-size: 0.9rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  box-shadow: inset 0 0 0 1px rgba(255, 79, 154, 0.1);
-}
-
-.ad-slot span {
-  max-width: 460px;
-}
-
-.leaderboard {
-  max-width: 1100px;
-  margin: 1.5rem auto 0;
-  min-height: 140px;
-}
-
-.inline-ad {
-  min-height: 120px;
-}
-
-.skyscraper {
-  min-height: 320px;
-}
-
-.rectangle {
-  min-height: 160px;
+  font-weight: 500;
 }
 
 .hero {
-  padding: 4rem 1.5rem 3rem;
+  padding: clamp(3.5rem, 8vw, 6rem) 0 0;
 }
 
-.hero-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 79, 154, 0.16),
-    rgba(17, 17, 25, 0.65)
-  );
-  border: 1px solid var(--border);
-  border-radius: calc(var(--radius) * 1.4);
-  padding: clamp(2.5rem, 5vw, 3.5rem);
+.hero__inner {
+  background:
+    linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 64, 175, 0.65)),
+    radial-gradient(circle at 15% 10%, rgba(248, 250, 255, 0.12), transparent 55%);
+  border: 1px solid var(--outline);
+  border-radius: var(--radius-lg);
+  padding: clamp(2.5rem, 6vw, 4rem);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
   position: relative;
   overflow: hidden;
-  box-shadow: var(--shadow);
 }
 
-.hero-inner::after {
+.hero__inner::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(
-    circle at 20% 20%,
-    rgba(255, 255, 255, 0.08),
-    transparent 55%
-  );
+  background: radial-gradient(circle at 80% 0%, rgba(249, 115, 22, 0.12), transparent 45%);
   mix-blend-mode: screen;
   pointer-events: none;
 }
 
 .hero-badge {
+  align-self: flex-start;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  padding: 0.4rem 0.9rem;
+  padding: 0.45rem 0.95rem;
   border-radius: 999px;
-  font-size: 0.8rem;
+  background: rgba(248, 250, 255, 0.12);
+  border: 1px solid rgba(248, 250, 255, 0.28);
   letter-spacing: 0.08em;
+  font-size: 0.75rem;
   text-transform: uppercase;
 }
 
 .hero h1 {
-  margin: 1rem 0 0.5rem;
-  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  font-size: clamp(2.3rem, 7vw, 3.8rem);
   letter-spacing: -0.02em;
-}
-
-.hero .subtitle {
-  max-width: 650px;
   margin: 0;
-  color: var(--muted);
-  font-size: 1.05rem;
 }
 
-.hero-stats {
-  margin: 2.5rem 0 2rem;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.stat-card {
-  background: rgba(15, 15, 25, 0.55);
-  border: 1px solid var(--glass);
-  border-radius: var(--radius);
-  padding: 1.25rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  backdrop-filter: blur(8px);
-}
-
-.stat-value {
-  font-size: 2rem;
-  font-weight: 700;
-}
-
-.stat-label {
-  font-size: 0.9rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted);
+.subtitle {
+  margin: 0;
+  max-width: 52ch;
+  color: rgba(226, 232, 240, 0.82);
+  font-size: clamp(1rem, 2.4vw, 1.125rem);
 }
 
 .hero-actions {
@@ -242,552 +171,484 @@ footer {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
-  background: var(--accent);
+  gap: 0.5rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   color: #fff;
-  font-weight: 600;
   border: none;
-  padding: 0.9rem 1.4rem;
   border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
   cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
-  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 16px 30px rgba(249, 115, 22, 0.25);
 }
 
-.btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 32px rgba(255, 79, 154, 0.35);
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(249, 115, 22, 0.28);
 }
 
 .btn.ghost {
-  background: transparent;
-  border: 1px solid var(--accent);
-  color: var(--accent);
+  background: rgba(248, 250, 255, 0.08);
+  color: var(--text);
+  box-shadow: none;
+  border: 1px solid rgba(248, 250, 255, 0.2);
+}
+
+.btn.ghost:hover,
+.btn.ghost:focus-visible {
+  background: rgba(248, 250, 255, 0.16);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.stat-card {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid rgba(148, 163, 255, 0.2);
+}
+
+.stat-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.stat-label {
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .hero-highlights {
-  margin: 2rem 0 1rem;
+  margin: 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.8rem;
+  gap: 0.65rem;
+  color: rgba(226, 232, 240, 0.82);
 }
 
 .hero-highlights li {
   display: flex;
-  gap: 0.6rem;
+  gap: 0.5rem;
   align-items: flex-start;
-  font-size: 0.95rem;
-  color: var(--muted);
 }
 
 .hero-highlights li::before {
-  content: "";
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--accent);
-  margin-top: 0.45rem;
+  content: "•";
+  color: var(--accent-strong);
+  font-weight: 700;
+  margin-top: -0.1rem;
 }
 
 .hero-note {
   margin: 0;
+  color: rgba(226, 232, 240, 0.66);
   font-size: 0.85rem;
-  color: var(--muted);
 }
 
-.intro {
-  padding: 3rem 1.5rem 1rem;
-}
-
-.intro-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  display: grid;
-  gap: 2.5rem;
-}
-
-.intro-copy {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.intro-grid {
-  display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.info-card {
-  background: rgba(15, 15, 25, 0.7);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.6rem 1.5rem;
-  display: grid;
-  gap: 0.65rem;
-  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.25);
-}
-
-.info-card h3 {
-  margin: 0;
-  font-size: 1.15rem;
-}
-
-.directory {
-  padding: 3rem 1.5rem 4rem;
-}
-
-.directory-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: grid;
-  gap: 2.5rem;
-}
-
-.directory-heading {
-  display: grid;
-  gap: 0.5rem;
-  max-width: 720px;
-}
-
-.directory-layout {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(0, 1fr) 320px;
-  align-items: start;
-}
-
-.directory-main {
-  display: flex;
-  flex-direction: column;
-  gap: 2.5rem;
-}
-
-.directory-controls {
-  background: rgba(15, 15, 25, 0.72);
-  border: 1px solid var(--border);
-  border-radius: calc(var(--radius) + 4px);
-  padding: 1.8rem;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
-}
-
-.directory-controls .controls {
-  padding: 0;
-  margin: 0;
-}
-
-.directory-controls .section-header {
-  margin-bottom: 1.5rem;
-}
-
-.directory-sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  position: sticky;
-  top: 6rem;
-}
-
-.sidebar-card {
-  background: rgba(15, 15, 25, 0.8);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.8rem 1.6rem;
-  display: grid;
-  gap: 0.8rem;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.28);
-}
-
-.sidebar-card h3 {
-  margin: 0;
-}
-
-.category-board {
-  padding: 0;
-  display: grid;
-  gap: 1.5rem;
-}
-
-.category-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.category-header h2 {
-  font-size: 1.75rem;
-  margin: 0;
-}
-
-.category-header p {
-  margin: 0;
-  color: var(--muted);
-}
-
-.category-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.category-tile {
-  text-align: left;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: calc(var(--radius) - 4px);
-  padding: 1.4rem 1.3rem;
-  color: inherit;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    border 0.2s ease,
-    box-shadow 0.2s ease;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.category-tile:hover {
-  transform: translateY(-3px);
-  border-color: rgba(255, 79, 154, 0.4);
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.25);
-}
-
-.category-tile.active {
-  border-color: var(--accent);
-  box-shadow: 0 18px 36px rgba(255, 79, 154, 0.25);
-  background: var(--accent-soft);
-}
-
-.category-title {
-  font-weight: 600;
-  font-size: 1.1rem;
-}
-
-.category-meta {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted);
-}
-
-.category-desc {
-  font-size: 0.85rem;
-  color: var(--muted);
-}
-
-.controls {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.controls input,
-.controls select,
-.controls button,
-.modal-actions button {
-  background: var(--bg-panel);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.8rem 1rem;
-  font-size: 0.95rem;
-}
-
-.controls button,
-.modal-actions button {
-  cursor: pointer;
-}
-
-.controls input:focus,
-.controls select:focus,
-.controls button:focus,
-.modal-actions button:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+.section {
+  position: relative;
 }
 
 .section-header {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  margin-bottom: 1.5rem;
+  gap: 0.5rem;
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .section-header h2 {
   margin: 0;
-  font-size: 1.8rem;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  letter-spacing: -0.01em;
 }
 
 .section-header p {
   margin: 0;
-  color: var(--muted);
+  color: rgba(226, 232, 240, 0.78);
+  max-width: 60ch;
 }
 
-.featured-section {
-  width: 100%;
-}
-
-.featured-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.featured-card {
-  background: linear-gradient(
-    145deg,
-    rgba(255, 79, 154, 0.25),
-    rgba(24, 24, 35, 0.95)
-  );
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: calc(var(--radius) + 6px);
-  padding: 2.2rem 2rem;
-  box-shadow: var(--shadow);
+.intro__inner {
   display: flex;
   flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.intro-grid {
+  display: grid;
   gap: 1rem;
-  position: relative;
-  overflow: hidden;
 }
 
-.featured-rank {
-  position: absolute;
-  top: 1.2rem;
-  right: 1.4rem;
-  font-weight: 700;
+.info-card {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--outline);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.info-card h3 {
+  margin: 0 0 0.5rem;
   font-size: 1.1rem;
-  color: rgba(255, 255, 255, 0.65);
 }
 
-.featured-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 0.5rem;
+.info-card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.82);
 }
 
-.featured-card .card-title {
-  font-size: 1.4rem;
-}
-
-.featured-card .card-score {
-  font-size: 1.05rem;
-}
-
-.trending-section {
-  width: 100%;
-}
-
-.trending-grid {
+.filter-panel {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.trending-card {
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.8rem 1.6rem;
-  display: flex;
-  flex-direction: column;
   gap: 0.75rem;
-  transition:
-    transform 0.2s ease,
-    border 0.2s ease;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  border: 1px solid var(--outline);
+  box-shadow: var(--shadow-soft);
 }
 
-.trending-card:hover {
-  transform: translateY(-3px);
-  border-color: rgba(255, 79, 154, 0.45);
-}
-
-.card-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 0.8rem;
+.filter-panel input,
+.filter-panel select {
+  width: 100%;
   border-radius: 999px;
-  font-size: 0.75rem;
+  border: 1px solid rgba(148, 163, 255, 0.35);
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--text);
+  padding: 0.65rem 1rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  appearance: none;
+}
+
+.filter-panel input::placeholder {
+  color: rgba(226, 232, 240, 0.55);
+}
+
+.category-board {
+  margin-top: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  scroll-snap-type: x mandatory;
+}
+
+.category-board::-webkit-scrollbar {
+  height: 6px;
+}
+
+.category-board::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 255, 0.4);
+  border-radius: 999px;
+}
+
+.category-tile {
+  flex: 0 0 auto;
+  min-width: 180px;
+  background: var(--surface-strong);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  border: 1px solid var(--outline);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  scroll-snap-align: start;
+  transition: transform 0.2s ease, border 0.2s ease;
+}
+
+.category-tile:hover,
+.category-tile:focus-visible,
+.category-tile[aria-pressed="true"] {
+  transform: translateY(-2px);
+  border-color: var(--accent-strong);
+}
+
+.category-title {
+  font-weight: 600;
+  display: block;
+}
+
+.category-count {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.category-description {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.house-slot {
+  margin: clamp(2rem, 4vw, 3rem) 0;
+  border: 1px dashed rgba(248, 250, 255, 0.35);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.65);
   letter-spacing: 0.08em;
-  background: var(--accent-soft);
-  color: var(--accent);
   text-transform: uppercase;
+  font-size: 0.8rem;
 }
 
-.trending-meta {
-  font-size: 0.9rem;
-  color: var(--muted);
-}
-
-main#grid {
+.card-grid {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.25rem, 3vw, 1.75rem);
 }
 
 .card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.6rem 1.4rem;
-  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+  background: var(--card);
+  color: var(--ink);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.4rem, 3vw, 1.75rem);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  position: relative;
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .card-identity {
   display: flex;
+  align-items: center;
   gap: 0.85rem;
-  align-items: center;
-}
-
-.card-avatar {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 14px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--accent-soft);
-  color: var(--accent);
-  font-weight: 700;
-  letter-spacing: 0.08em;
 }
 
 .card-title-wrap {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.2rem;
+}
+
+.card-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(96, 165, 250, 0.65));
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
 }
 
 .card-title {
-  font-size: 1.2rem;
-  font-weight: 600;
   margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: -0.01em;
 }
 
 .card-subtitle {
   margin: 0;
-  font-size: 0.85rem;
-  color: var(--muted);
+  color: rgba(15, 23, 42, 0.62);
+  font-size: 0.9rem;
 }
 
 .card-score {
-  font-weight: 600;
+  font-weight: 700;
   color: var(--accent);
 }
 
 .card-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem 1rem;
+  gap: 0.5rem 1rem;
   font-size: 0.85rem;
-  color: var(--muted);
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.card-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.card-description {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.74);
 }
 
 .card-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.45rem;
+  gap: 0.5rem;
 }
 
 .card-tag {
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: rgba(15, 23, 42, 0.06);
   border-radius: 999px;
-  padding: 0.3rem 0.75rem;
-  font-size: 0.75rem;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(15, 23, 42, 0.12);
 }
 
 .card-feature-list {
-  list-style: none;
-  padding: 0;
   margin: 0;
+  padding-left: 1.1rem;
   display: grid;
-  gap: 0.45rem;
-}
-
-.card-feature-list li {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
+  gap: 0.35rem;
+  color: rgba(15, 23, 42, 0.7);
   font-size: 0.9rem;
-}
-
-.card-feature-list li::before {
-  content: "";
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
 }
 
 .card-actions {
   display: flex;
-  gap: 0.75rem;
+  justify-content: flex-start;
+  gap: 0.5rem;
 }
 
 .card-actions a {
-  text-decoration: none;
-  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
   font-weight: 600;
 }
 
-.card-actions a:hover {
-  text-decoration: underline;
+.featured-card .card-actions a {
+  background: linear-gradient(135deg, rgba(248, 250, 255, 0.2), rgba(148, 163, 255, 0.45));
+  border: 1px solid rgba(248, 250, 255, 0.35);
 }
 
-.empty-state {
-  text-align: center;
-  background: rgba(15, 15, 25, 0.7);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 3rem 1.5rem;
-  box-shadow: var(--shadow);
+.featured-grid {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.featured-card {
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.35rem, 3vw, 1.75rem);
+  border: 1px solid var(--outline);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.featured-card .card-title,
+.featured-card .card-description,
+.featured-card .card-meta,
+.featured-card .card-feature-list,
+.featured-card .card-score {
+  color: var(--text);
+}
+
+.featured-rank {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.featured-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.trending-grid {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.trending-card {
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.25rem, 3vw, 1.6rem);
+  border: 1px solid var(--outline);
   display: grid;
   gap: 0.75rem;
 }
 
-.newsletter {
-  padding: 3.5rem 1.5rem;
+.card-chip {
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(248, 250, 255, 0.1);
+  border: 1px solid rgba(248, 250, 255, 0.28);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.newsletter-inner {
-  max-width: 850px;
-  margin: 0 auto;
-  background: rgba(15, 15, 25, 0.7);
-  border: 1px solid var(--border);
-  border-radius: calc(var(--radius) + 6px);
-  padding: 2.8rem 2.5rem;
+.trending-card h3 {
+  margin: 0;
+  color: var(--text);
+}
+
+.trending-meta {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.65);
+  font-size: 0.9rem;
+}
+
+.trending-card .card-description {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.trending-card .card-actions a {
+  background: rgba(248, 250, 255, 0.12);
+  border: 1px solid rgba(248, 250, 255, 0.3);
+}
+
+.advertise__inner {
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 5vw, 3rem);
+  border: 1px solid var(--outline);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  text-align: center;
+}
+
+.advertise-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.newsletter {
+  padding-bottom: clamp(3rem, 6vw, 5rem);
+}
+
+.newsletter__inner {
+  background: rgba(248, 250, 255, 0.06);
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 5vw, 3rem);
+  border: 1px solid var(--outline);
   display: grid;
   gap: 1rem;
   text-align: center;
-  box-shadow: var(--shadow);
-}
-
-.newsletter-inner h2 {
-  margin: 0;
-  font-size: 2rem;
-}
-
-.newsletter-inner p {
-  margin: 0;
-  color: var(--muted);
 }
 
 .newsletter-form {
@@ -798,138 +659,67 @@ main#grid {
 }
 
 .newsletter-form input {
-  width: min(320px, 100%);
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
+  width: min(100%, 360px);
   border-radius: 999px;
-  padding: 0.85rem 1.1rem;
+  border: 1px solid rgba(248, 250, 255, 0.35);
+  background: rgba(4, 5, 19, 0.75);
   color: var(--text);
-}
-
-.newsletter small {
-  color: var(--muted);
-}
-
-.content-block {
-  padding: 3.5rem 1.5rem;
-}
-
-.content-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  display: grid;
-  gap: 2.5rem;
-}
-
-.content-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.content-card {
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.75rem 1.6rem;
-  display: grid;
-  gap: 0.75rem;
-  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
-}
-
-.content-card h3 {
-  margin: 0;
-}
-
-.content-card ul {
-  margin: 0;
-  padding-left: 1.1rem;
-  color: var(--muted);
-  display: grid;
-  gap: 0.45rem;
-}
-
-.cta-banner {
-  padding: 3.5rem 1.5rem;
-  background: linear-gradient(120deg, rgba(255, 79, 154, 0.25), rgba(24, 24, 35, 0.85));
-  border-block: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.cta-inner {
-  max-width: 1050px;
-  margin: 0 auto;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.cta-copy {
-  max-width: 520px;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.cta-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-footer {
-  border-top: 1px solid var(--border);
-  padding: 3rem 1.5rem 2rem;
-  background: rgba(15, 15, 25, 0.6);
-  color: var(--muted);
-}
-
-.footer-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2.5rem;
-  align-items: flex-start;
-  justify-content: space-between;
-}
-
-.footer-brand {
-  max-width: 360px;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.footer-nav {
-  display: grid;
-  gap: 0.65rem 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-}
-
-.footer-nav a {
-  color: var(--text);
-  text-decoration: none;
+  padding: 0.65rem 1rem;
   font-size: 0.95rem;
 }
 
-.footer-nav a:hover {
-  text-decoration: underline;
+.newsletter small {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.footer {
+  margin-top: clamp(2rem, 4vw, 3rem);
+  padding: clamp(2.5rem, 6vw, 3.5rem) 0 clamp(2rem, 4vw, 3rem);
+  background: rgba(4, 5, 19, 0.85);
+  border-top: 1px solid var(--outline);
+}
+
+.footer__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.footer-brand strong {
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.footer-brand p {
+  margin: 0.5rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.footer-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.95rem;
 }
 
 .footer-disclaimer {
-  max-width: 1100px;
-  margin: 2rem auto 0;
+  margin: 1.5rem auto 0;
+  max-width: 60ch;
   text-align: center;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 255, 0.6);
 }
 
 .modal {
   position: fixed;
   inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(5, 5, 10, 0.85);
-  z-index: 100;
+  display: grid;
+  place-items: center;
+  background: rgba(4, 6, 19, 0.92);
+  backdrop-filter: blur(4px);
+  padding: 1.5rem;
 }
 
 .modal.hidden {
@@ -937,20 +727,28 @@ footer {
 }
 
 .modal-content {
-  background: var(--bg-card);
-  border-radius: var(--radius);
-  padding: 2rem 2.5rem;
+  background: rgba(248, 250, 255, 0.08);
+  border: 1px solid rgba(248, 250, 255, 0.32);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
   text-align: center;
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-  max-width: 320px;
+  display: grid;
+  gap: 1rem;
 }
 
 .modal-actions {
-  margin-top: 1.5rem;
   display: flex;
-  gap: 1rem;
-  justify-content: center;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.empty-state {
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  text-align: center;
+  border: 1px solid var(--outline);
+  color: rgba(226, 232, 240, 0.78);
 }
 
 .sr-only {
@@ -961,69 +759,65 @@ footer {
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
   border: 0;
 }
 
-@media (max-width: 960px) {
-  .site-header-inner {
-    flex-direction: column;
-    align-items: flex-start;
+@media (min-width: 640px) {
+  .filter-panel {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .main-nav {
-    width: 100%;
-    gap: 1rem;
-  }
-
-  .directory-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .directory-sidebar {
-    position: static;
+  .modal-actions {
     flex-direction: row;
-    flex-wrap: wrap;
     justify-content: center;
-  }
-
-  .directory-sidebar > * {
-    flex: 1 1 280px;
   }
 }
 
-@media (max-width: 720px) {
-  .hero-inner {
-    padding: 2.2rem;
+@media (min-width: 768px) {
+  main {
+    gap: clamp(3.5rem, 5vw, 6rem);
+  }
+
+  .intro-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .featured-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .trending-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .advertise-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 900px) {
+  .filter-panel {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    align-items: center;
+  }
+
+  .card-header {
+    align-items: center;
+  }
+
+  .card-meta {
+    justify-content: flex-start;
   }
 
   .hero-stats {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .card {
-    padding: 1.4rem 1.2rem;
-  }
-}
-
-@media (max-width: 640px) {
-  .hero-highlights {
-    gap: 0.65rem;
-  }
-
-  .intro {
-    padding-top: 2.5rem;
-  }
-
-  .leaderboard {
-    margin: 1rem 1.5rem 0;
-  }
-
-  .cta-inner {
-    flex-direction: column;
+  .footer__inner {
+    flex-direction: row;
+    justify-content: space-between;
     align-items: flex-start;
-  }
-
-  .footer-nav {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the landing page markup with a mobile-first hero, streamlined filters, and updated sections for featured, directory, and calls to action
- refresh the global styling to introduce a gradient backdrop, light card UI, and touch-friendly controls that mirror a curated rankings experience

## Testing
- python -m http.server 3000

------
https://chatgpt.com/codex/tasks/task_e_68d4a1f696a48331b71ec26ba5d0ed5d