### PR TITLE
Refresh homepage styling and copy static assets to dist

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,6 +8,8 @@ const rootDir = path.resolve(__dirname, '..');
 const srcDir = path.join(rootDir, 'src');
 const templateDir = path.join(srcDir, 'templates');
 const dataDir = path.join(srcDir, 'data');
+const cssDir = path.join(srcDir, 'css');
+const jsDir = path.join(srcDir, 'js');
 const distDir = path.join(rootDir, 'dist');
 const publicDir = path.join(rootDir, 'public');
 
@@ -38,6 +40,15 @@ function writeFile(targetPath, content) {
 function copyPublicAssets() {
   if (fs.existsSync(publicDir)) {
     fs.cpSync(publicDir, distDir, { recursive: true });
+  }
+}
+
+function copyStaticAssets() {
+  if (fs.existsSync(cssDir)) {
+    fs.cpSync(cssDir, path.join(distDir, 'css'), { recursive: true });
+  }
+  if (fs.existsSync(jsDir)) {
+    fs.cpSync(jsDir, path.join(distDir, 'js'), { recursive: true });
   }
 }
 
@@ -91,6 +102,7 @@ async function buildSite() {
   fs.rmSync(distDir, { recursive: true, force: true });
   fs.mkdirSync(distDir, { recursive: true });
   copyPublicAssets();
+  copyStaticAssets();
 
   const indexHtml = renderTemplate('index.njk', {
     categories,

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,11 +1,13 @@
 :root {
-  --bg: #0f0f15;
-  --bg-alt: #1a1a24;
-  --text: #f5f6fb;
-  --muted: #9aa0b5;
+  --bg: #04020d;
+  --bg-alt: rgba(16, 16, 28, 0.92);
+  --surface: rgba(12, 12, 24, 0.8);
+  --text: #f6f7ff;
+  --muted: #98a0c3;
   --accent: #ff4f8b;
-  --accent-soft: rgba(255, 79, 139, 0.15);
-  --border: #2a2a39;
+  --accent-soft: rgba(255, 79, 139, 0.18);
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.22);
   --success: #4ade80;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
@@ -15,10 +17,13 @@
 }
 
 body {
-  background: var(--bg);
-  color: var(--text);
   margin: 0;
+  min-height: 100vh;
   line-height: 1.6;
+  color: var(--text);
+  background: radial-gradient(circle at 15% 15%, rgba(255, 79, 139, 0.14), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(46, 110, 255, 0.18), transparent 60%),
+    linear-gradient(160deg, #050518 0%, #04020d 55%, #07060f 100%);
 }
 
 a {
@@ -32,8 +37,12 @@ a:focus {
 }
 
 .container {
-  width: min(1100px, 92vw);
+  width: min(1180px, 92vw);
   margin: 0 auto;
+}
+
+.site-main {
+  padding: 3.5rem 0 4.5rem;
 }
 
 .skip-link {
@@ -50,33 +59,60 @@ a:focus {
   top: 1rem;
   width: auto;
   height: auto;
-  padding: 0.5rem 1rem;
+  padding: 0.6rem 1.2rem;
   background: var(--accent);
-  color: #000;
-  border-radius: 0.5rem;
+  color: #050518;
+  border-radius: 999px;
   z-index: 1000;
 }
 
 .site-header {
-  background: var(--bg-alt);
-  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(12px);
+  background: rgba(4, 4, 12, 0.7);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .header-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 0;
+  padding: 1.1rem 0;
+  gap: 1.5rem;
+}
+
+.header-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
 }
 
 .logo {
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+  color: #fff;
+}
+
+.logo-tagline {
+  font-size: 0.85rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.primary-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
 }
 
 .nav-list {
   display: flex;
-  gap: 1rem;
+  align-items: center;
+  gap: 1.5rem;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -87,79 +123,310 @@ a:focus {
   font-weight: 500;
 }
 
+.nav-cta {
+  padding: 0.55rem 1.3rem;
+  font-size: 0.9rem;
+  border-radius: 999px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.65rem 1.55rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #ff4f8b, #ff8f9f);
+  color: #0b0614;
+  box-shadow: 0 12px 28px rgba(255, 79, 139, 0.35);
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
 .hero {
-  padding: 3rem 0 2rem;
+  padding-top: 1rem;
 }
 
-.hero h1 {
-  font-size: clamp(2rem, 3vw, 2.6rem);
-  margin-bottom: 0.5rem;
+.hero__surface {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr);
+  gap: clamp(2rem, 4vw, 3.5rem);
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 5vw, 3rem);
+  overflow: hidden;
+  box-shadow: 0 35px 80px rgba(4, 5, 18, 0.55);
 }
 
-.hero p {
-  max-width: 620px;
+.hero__surface::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 79, 139, 0.22), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(76, 143, 255, 0.2), transparent 60%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.hero__content,
+.hero__aside {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
   color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 1rem;
+}
+
+.hero__lead {
+  color: #d8daea;
+  font-size: 1.05rem;
+  max-width: 560px;
+}
+
+.hero__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 1.8rem 0 2rem;
+}
+
+.hero__stats li {
+  min-width: 140px;
+}
+
+.hero__stat-value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.hero__stat-label {
+  display: block;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.hero__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
 }
 
 .search-bar {
-  margin-top: 1.5rem;
   position: relative;
 }
 
 .search-bar input {
   width: 100%;
   padding: 0.85rem 1rem;
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  background: var(--bg-alt);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.9rem;
+  background: rgba(8, 8, 20, 0.9);
   color: var(--text);
   font-size: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .filter-group {
-  margin-top: 1.25rem;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .filter-chip {
-  border: 1px solid var(--border);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 999px;
-  padding: 0.4rem 1rem;
-  background: transparent;
+  padding: 0.45rem 1.1rem;
+  background: rgba(10, 10, 22, 0.75);
   color: var(--text);
   cursor: pointer;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
 }
 
 .filter-chip.is-active,
 .filter-chip:hover {
   border-color: var(--accent);
   color: var(--accent);
+  background: rgba(255, 79, 139, 0.08);
+}
+
+.hero__aside {
+  align-self: stretch;
+  background: rgba(8, 8, 18, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  box-shadow: 0 24px 48px rgba(5, 5, 18, 0.45);
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero__checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero__checklist li {
+  position: relative;
+  padding-left: 1.8rem;
+  color: #d8daea;
+}
+
+.hero__checklist li::before {
+  content: '✓';
+  position: absolute;
+  left: 0.2rem;
+  top: 0.15rem;
+  color: var(--success);
+  font-weight: 700;
+}
+
+.hero__aside-note {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.section {
+  margin-top: 3.5rem;
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+
+.section-subtitle {
+  color: var(--muted);
+  margin: 0.35rem 0 0;
+}
+
+.section-link {
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.section-link:hover {
+  color: var(--accent);
 }
 
 .section-title {
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-  font-size: 1.4rem;
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2rem);
 }
 
 .tool-grid {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  margin-bottom: 3rem;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .tool-card {
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  padding: 1.5rem;
+  position: relative;
+  background: rgba(10, 10, 24, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.35rem;
+  padding: 1.75rem;
+  min-height: 260px;
   display: flex;
   flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: 0 22px 45px rgba(5, 6, 18, 0.5);
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.tool-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 1.35rem;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(255, 79, 139, 0.55), rgba(76, 143, 255, 0.4));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+}
+
+.tool-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 32px 70px rgba(4, 5, 18, 0.55);
+}
+
+.tool-card:hover::after {
+  opacity: 1;
+}
+
+.tool-card__heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
   gap: 0.75rem;
-  min-height: 260px;
+}
+
+.tool-card__heading h3,
+.tool-card__heading h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.tool-card__category {
+  font-size: 0.85rem;
+  color: var(--muted);
 }
 
 .tool-card__meta {
@@ -168,8 +435,9 @@ a:focus {
 }
 
 .tool-card__description {
-  color: #d5d8e8;
-  font-size: 0.95rem;
+  color: #e3e5f5;
+  font-size: 0.96rem;
+  flex: 1;
 }
 
 .pill-list {
@@ -185,80 +453,84 @@ a:focus {
   background: var(--accent-soft);
   color: var(--accent);
   border-radius: 999px;
-  padding: 0.35rem 0.8rem;
+  padding: 0.4rem 0.85rem;
   font-size: 0.8rem;
+  font-weight: 600;
 }
 
 .page-header {
-  padding: 2rem 0 1rem;
+  padding: 2.2rem 0 1.5rem;
 }
 
 .page-header p {
   color: var(--muted);
+  max-width: 700px;
 }
 
 .breadcrumb {
   font-size: 0.85rem;
   color: var(--muted);
+  margin-bottom: 1.25rem;
+}
+
+.breadcrumb a {
+  color: var(--muted);
 }
 
 .tool-hero {
-  padding: 2rem 0;
+  background: rgba(10, 10, 24, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  margin-bottom: 2.5rem;
+  box-shadow: 0 30px 60px rgba(5, 5, 18, 0.5);
+}
+
+.tool-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 79, 139, 0.16);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 1rem;
 }
 
 .tool-hero__vendor {
   color: var(--muted);
+  margin-bottom: 0.75rem;
 }
 
 .tool-hero__description {
-  margin-top: 1rem;
+  color: #e2e4f5;
   max-width: 700px;
 }
 
 .tool-actions {
-  margin-top: 1.5rem;
+  margin-top: 1.75rem;
   display: flex;
-  gap: 1rem;
   flex-wrap: wrap;
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  padding: 0.6rem 1.4rem;
-  font-weight: 600;
-  transition: transform 0.2s ease;
-}
-
-.btn:hover {
-  transform: translateY(-1px);
-}
-
-.btn-primary {
-  background: var(--accent);
-  color: #fff;
-}
-
-.btn-secondary {
-  background: transparent;
-  color: var(--text);
-  border: 1px solid var(--border);
+  gap: 0.85rem;
 }
 
 .tool-details {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  margin-bottom: 3rem;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-bottom: 3.5rem;
 }
 
 .tool-panel {
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  padding: 1.5rem;
+  background: rgba(8, 8, 18, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: 0 22px 40px rgba(5, 5, 18, 0.45);
 }
 
 .tool-panel h2 {
@@ -268,7 +540,7 @@ a:focus {
 .tool-meta {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 0.4rem 0.75rem;
+  gap: 0.5rem 0.9rem;
   margin: 0;
 }
 
@@ -280,10 +552,14 @@ a:focus {
   margin: 0;
 }
 
+.alternatives {
+  margin-top: 3rem;
+}
+
 .site-footer {
-  border-top: 1px solid var(--border);
-  background: var(--bg-alt);
-  padding: 2rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(8, 8, 18, 0.85);
+  padding: 2.5rem 0;
   font-size: 0.9rem;
   color: var(--muted);
 }
@@ -291,16 +567,16 @@ a:focus {
 .footer-links {
   list-style: none;
   padding: 0;
-  margin: 1rem 0 0;
+  margin: 1.25rem 0 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .age-gate {
   position: fixed;
   inset: 0;
-  background: rgba(12, 12, 18, 0.88);
+  background: rgba(4, 4, 12, 0.92);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -308,12 +584,13 @@ a:focus {
 }
 
 .age-gate__dialog {
-  background: var(--bg-alt);
+  background: rgba(8, 8, 18, 0.95);
   border: 1px solid var(--accent);
   padding: 2rem;
   border-radius: 1rem;
   max-width: 420px;
   text-align: center;
+  box-shadow: 0 28px 60px rgba(4, 4, 16, 0.6);
 }
 
 .age-gate__actions {
@@ -321,6 +598,14 @@ a:focus {
   gap: 1rem;
   justify-content: center;
   margin: 1.5rem 0;
+}
+
+.prose {
+  max-width: 780px;
+}
+
+.prose p + p {
+  margin-top: 1rem;
 }
 
 .visually-hidden {
@@ -335,14 +620,80 @@ a:focus {
   border: 0;
 }
 
+@media (max-width: 1024px) {
+  .hero__surface {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__aside {
+    order: -1;
+  }
+
+  .primary-nav {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+}
+
 @media (max-width: 768px) {
+  .site-header {
+    position: static;
+  }
+
   .header-inner {
     flex-direction: column;
-    gap: 1rem;
     align-items: flex-start;
+  }
+
+  .primary-nav {
+    width: 100%;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .nav-list {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .hero__stats {
+    gap: 1rem;
   }
 
   .tool-card {
     min-height: auto;
+  }
+
+  .tool-hero {
+    padding: 1.75rem;
+  }
+
+  .tool-details {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 540px) {
+  .hero__surface {
+    padding: 1.75rem;
+  }
+
+  .hero__controls {
+    gap: 0.9rem;
+  }
+
+  .section-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tool-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .footer-links {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/src/templates/_layout.njk
+++ b/src/templates/_layout.njk
@@ -18,14 +18,18 @@
   <a href="#main" class="skip-link">Skip to content</a>
   <header class="site-header">
     <div class="container header-inner">
-      <a class="logo" href="/">AiPornDirect</a>
-      <nav aria-label="Primary">
+      <div class="header-brand">
+        <a class="logo" href="/">AiPornDirect</a>
+        <span class="logo-tagline">Curated NSFW AI software</span>
+      </div>
+      <nav aria-label="Primary" class="primary-nav">
         <ul class="nav-list">
           <li><a href="/">Directory</a></li>
           <li><a href="/prohibited-content.html">Prohibited Content</a></li>
           <li><a href="/privacy.html">Privacy</a></li>
           <li><a href="/dmca.html">DMCA</a></li>
         </ul>
+        <a class="btn btn-primary nav-cta" href="mailto:submit@aiporndirect.com">Submit a tool</a>
       </nav>
     </div>
   </header>
@@ -42,7 +46,7 @@
     </div>
   </div>
 
-  <main id="main" class="site-main container">
+  <main id="main" class="site-main">
     {% block content %}{% endblock %}
   </main>
 

--- a/src/templates/category.njk
+++ b/src/templates/category.njk
@@ -4,28 +4,33 @@
 <meta property="og:description" content="{{ description }}">
 {% endblock %}
 {% block content %}
-<header class="page-header">
-  <p class="breadcrumb"><a href="/">Home</a> / {{ category.name }}</p>
-  <h1>{{ category.name }}</h1>
-  <p>{{ category.description }}</p>
-</header>
+<div class="container">
+  <header class="page-header">
+    <p class="breadcrumb"><a href="/">Home</a> / {{ category.name }}</p>
+    <h1>{{ category.name }}</h1>
+    <p>{{ category.description }}</p>
+  </header>
 
-<section>
-  <div class="tool-grid">
-    {% for tool in tools %}
-    <article class="tool-card">
-      <h2><a href="/tool/{{ tool.slug }}/">{{ tool.name }}</a></h2>
-      <p class="tool-card__meta">By {{ tool.vendor }} &middot; {{ tool.pricing | capitalize }} &middot; {{ tool.status | capitalize }}</p>
-      <p class="tool-card__description">{{ tool.description | truncate(220, true, '…') }}</p>
-      <ul class="pill-list">
-        {% for tag in tool.tags %}
-        <li class="pill">{{ tag }}</li>
-        {% endfor %}
-      </ul>
-    </article>
-    {% else %}
-    <p>No tools found for this category yet.</p>
-    {% endfor %}
-  </div>
-</section>
+  <section class="section">
+    <div class="tool-grid">
+      {% for tool in tools %}
+      <article class="tool-card">
+        <div class="tool-card__heading">
+          <h2><a href="/tool/{{ tool.slug }}/">{{ tool.name }}</a></h2>
+          <span class="tool-card__category">{{ tool.pricing | capitalize }} &middot; {{ tool.status | capitalize }}</span>
+        </div>
+        <p class="tool-card__meta">By {{ tool.vendor }}</p>
+        <p class="tool-card__description">{{ tool.description | truncate(220, true, '…') }}</p>
+        <ul class="pill-list">
+          {% for tag in tool.tags %}
+          <li class="pill">{{ tag }}</li>
+          {% endfor %}
+        </ul>
+      </article>
+      {% else %}
+      <p>No tools found for this category yet.</p>
+      {% endfor %}
+    </div>
+  </section>
+</div>
 {% endblock %}

--- a/src/templates/dmca.njk
+++ b/src/templates/dmca.njk
@@ -1,11 +1,13 @@
 {% extends "_layout.njk" %}
 {% set title = 'DMCA & Takedowns — AiPornDirect' %}
 {% block content %}
-<header class="page-header">
-  <h1>DMCA & Takedowns</h1>
-  <p>We respect the rights of creators and require partners to do the same.</p>
-</header>
-<p>If you believe a listing on AiPornDirect links to content that infringes your copyright or violates your privacy, contact our DMCA agent. Include the URL, a description of the work, your contact details, and a statement under penalty of perjury that you are authorized to act.</p>
-<p>Send notices to <a href="mailto:dmca@aiporndirect.com">dmca@aiporndirect.com</a> or AiPornDirect DMCA Agent, 88 Market Street Suite 200, San Francisco, CA 94105. We will review submissions within three business days and update affected partners.</p>
-<p>We maintain a repeat-infringer policy and may remove tools that ignore takedown requirements.</p>
+<div class="container prose">
+  <header class="page-header">
+    <h1>DMCA &amp; Takedowns</h1>
+    <p>We respect the rights of creators and require partners to do the same.</p>
+  </header>
+  <p>If you believe a listing on AiPornDirect links to content that infringes your copyright or violates your privacy, contact our DMCA agent. Include the URL, a description of the work, your contact details, and a statement under penalty of perjury that you are authorized to act.</p>
+  <p>Send notices to <a href="mailto:dmca@aiporndirect.com">dmca@aiporndirect.com</a> or AiPornDirect DMCA Agent, 88 Market Street Suite 200, San Francisco, CA 94105. We will review submissions within three business days and update affected partners.</p>
+  <p>We maintain a repeat-infringer policy and may remove tools that ignore takedown requirements.</p>
+</div>
 {% endblock %}

--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -3,35 +3,82 @@
 {% set description = 'Explore verified NSFW AI generators, marketplaces, compliance tools, and automation platforms for adult creators.' %}
 {% block content %}
 <section class="hero">
-  <h1>Build adult AI products without guesswork</h1>
-  <p>AiPornDirect curates mature AI software with transparent safety practices, compliance notes, and monetization data so you can ship faster.</p>
-  <div class="search-bar">
-    <label for="search" class="visually-hidden">Search tools</label>
-    <input id="search" type="search" placeholder="Search by name, category, or tag" autocomplete="off">
-  </div>
-  <div class="filter-group" id="category-filter" data-categories='{{ categories | dump }}'>
-    <button class="filter-chip is-active" data-category="all">All</button>
-    {% for category in categories %}
-    <button class="filter-chip" data-category="{{ category.id }}">{{ category.name }}</button>
-    {% endfor %}
+  <div class="container">
+    <div class="hero__surface">
+      <div class="hero__content">
+        <p class="hero__eyebrow">Responsible launches for mature AI founders</p>
+        <h1>Build adult AI products without guesswork</h1>
+        <p class="hero__lead">AiPornDirect curates NSFW AI software with transparent guardrails, compliance notes, and monetization data so you can move from idea to launch with confidence.</p>
+
+        <ul class="hero__stats">
+          <li>
+            <span class="hero__stat-value">{{ tools | length }}</span>
+            <span class="hero__stat-label">Vetted tools</span>
+          </li>
+          <li>
+            <span class="hero__stat-value">{{ categories | length }}</span>
+            <span class="hero__stat-label">Niches covered</span>
+          </li>
+          <li>
+            <span class="hero__stat-value">24/7</span>
+            <span class="hero__stat-label">Human review</span>
+          </li>
+        </ul>
+
+        <div class="hero__controls">
+          <div class="search-bar">
+            <label for="search" class="visually-hidden">Search tools</label>
+            <input id="search" type="search" placeholder="Search by name, category, or tag" autocomplete="off">
+          </div>
+          <div class="filter-group" id="category-filter" data-categories='{{ categories | dump }}'>
+            <button class="filter-chip is-active" data-category="all">All</button>
+            {% for category in categories %}
+            <button class="filter-chip" data-category="{{ category.id }}">{{ category.name }}</button>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+
+      <aside class="hero__aside" aria-label="Why teams use AiPornDirect">
+        <span class="hero__badge">What we evaluate</span>
+        <ul class="hero__checklist">
+          <li>Safety and moderation playbooks</li>
+          <li>Revenue models &amp; payout transparency</li>
+          <li>International compliance coverage</li>
+          <li>Community reputation &amp; support</li>
+        </ul>
+        <p class="hero__aside-note">Curators review each listing manually before it ships to the directory.</p>
+      </aside>
+    </div>
   </div>
 </section>
 
-<section aria-live="polite">
-  <h2 class="section-title">Featured tools</h2>
-  <div id="tool-grid" class="tool-grid">
-    {% for tool in tools %}
-    <article class="tool-card" data-slug='{{ tool.slug }}' data-categories='{{ tool.categories | dump }}' data-tags='{{ tool.tags | dump }}' data-name='{{ tool.name | lower }}' data-vendor='{{ tool.vendor | lower }}'>
-      <h3><a href="/tool/{{ tool.slug }}/">{{ tool.name }}</a></h3>
-      <p class="tool-card__meta">By {{ tool.vendor }} &middot; {{ tool.categories | join(', ') }}</p>
-      <p class="tool-card__description">{{ tool.description | truncate(220, true, '…') }}</p>
-      <ul class="pill-list">
-        <li class="pill">{{ tool.pricing | capitalize }}</li>
-        <li class="pill">{{ tool.adultLevel }}</li>
-        <li class="pill">{{ tool.status | capitalize }}</li>
-      </ul>
-    </article>
-    {% endfor %}
+<section class="section" aria-live="polite">
+  <div class="container">
+    <div class="section-heading">
+      <div>
+        <h2 class="section-title">Featured tools</h2>
+        <p class="section-subtitle">Discover trending launches and trusted operators from our community.</p>
+      </div>
+      <a class="section-link" href="mailto:submit@aiporndirect.com">Request a listing →</a>
+    </div>
+    <div id="tool-grid" class="tool-grid">
+      {% for tool in tools %}
+      <article class="tool-card" data-slug='{{ tool.slug }}' data-categories='{{ tool.categories | dump }}' data-tags='{{ tool.tags | dump }}' data-name='{{ tool.name | lower }}' data-vendor='{{ tool.vendor | lower }}'>
+        <div class="tool-card__heading">
+          <h3><a href="/tool/{{ tool.slug }}/">{{ tool.name }}</a></h3>
+          <span class="tool-card__category">{{ tool.categories | join(', ') }}</span>
+        </div>
+        <p class="tool-card__meta">By {{ tool.vendor }}</p>
+        <p class="tool-card__description">{{ tool.description | truncate(220, true, '…') }}</p>
+        <ul class="pill-list">
+          <li class="pill">{{ tool.pricing | capitalize }}</li>
+          <li class="pill">{{ tool.adultLevel }}</li>
+          <li class="pill">{{ tool.status | capitalize }}</li>
+        </ul>
+      </article>
+      {% endfor %}
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/src/templates/privacy.njk
+++ b/src/templates/privacy.njk
@@ -1,11 +1,13 @@
 {% extends "_layout.njk" %}
 {% set title = 'Privacy Policy — AiPornDirect' %}
 {% block content %}
-<header class="page-header">
-  <h1>Privacy Policy</h1>
-  <p>Last updated: January 2025</p>
-</header>
-<p>AiPornDirect publishes a catalog of mature AI software. We collect minimal personal data when you browse the site. Analytics rely on privacy-respecting, cookieless tracking to understand aggregate trends only. When you submit a tool or contact us via email, we store your message for follow-up and compliance purposes.</p>
-<p>Affiliate links on AiPornDirect may set third-party cookies to track conversions. We do not control the policies of those partners; please review their privacy statements before purchasing. You can disable affiliate tracking by using a private browser session.</p>
-<p>We retain server logs for 30 days to mitigate abuse. For removal requests or privacy questions email <a href="mailto:privacy@aiporndirect.com">privacy@aiporndirect.com</a>.</p>
+<div class="container prose">
+  <header class="page-header">
+    <h1>Privacy Policy</h1>
+    <p>Last updated: January 2025</p>
+  </header>
+  <p>AiPornDirect publishes a catalog of mature AI software. We collect minimal personal data when you browse the site. Analytics rely on privacy-respecting, cookieless tracking to understand aggregate trends only. When you submit a tool or contact us via email, we store your message for follow-up and compliance purposes.</p>
+  <p>Affiliate links on AiPornDirect may set third-party cookies to track conversions. We do not control the policies of those partners; please review their privacy statements before purchasing. You can disable affiliate tracking by using a private browser session.</p>
+  <p>We retain server logs for 30 days to mitigate abuse. For removal requests or privacy questions email <a href="mailto:privacy@aiporndirect.com">privacy@aiporndirect.com</a>.</p>
+</div>
 {% endblock %}

--- a/src/templates/prohibited-content.njk
+++ b/src/templates/prohibited-content.njk
@@ -1,10 +1,12 @@
 {% extends "_layout.njk" %}
 {% set title = 'Prohibited Content — AiPornDirect' %}
 {% block content %}
-<header class="page-header">
-  <h1>Prohibited Content</h1>
-  <p>We list only tools that reject illegal or harmful material.</p>
-</header>
-<p>AiPornDirect forbids any listing that facilitates child sexual abuse material, real-person deepfakes, incest, bestiality, non-consensual content, or other violations of international law. Partners must maintain clear 18+ age gates, honor DMCA requests, and verify consent for every performer or voice talent involved.</p>
-<p>Report suspicious activity to <a href="mailto:legal@aiporndirect.com">legal@aiporndirect.com</a>. We collaborate with trust-and-safety teams, legal counsel, and payment processors to remove risky listings quickly.</p>
+<div class="container prose">
+  <header class="page-header">
+    <h1>Prohibited Content</h1>
+    <p>We list only tools that reject illegal or harmful material.</p>
+  </header>
+  <p>AiPornDirect forbids any listing that facilitates child sexual abuse material, real-person deepfakes, incest, bestiality, non-consensual content, or other violations of international law. Partners must maintain clear 18+ age gates, honor DMCA requests, and verify consent for every performer or voice talent involved.</p>
+  <p>Report suspicious activity to <a href="mailto:legal@aiporndirect.com">legal@aiporndirect.com</a>. We collaborate with trust-and-safety teams, legal counsel, and payment processors to remove risky listings quickly.</p>
+</div>
 {% endblock %}

--- a/src/templates/tool.njk
+++ b/src/templates/tool.njk
@@ -7,92 +7,98 @@
 </script>
 {% endblock %}
 {% block content %}
-<nav class="breadcrumb"><a href="/">Home</a> / <a href="/category/{{ primaryCategory }}/">{{ primaryCategory | replace('-', ' ') | title }}</a> / {{ tool.name }}</nav>
-<header class="tool-hero">
-  <h1>{{ tool.name }}</h1>
-  <p class="tool-hero__vendor">By {{ tool.vendor }} &middot; {{ tool.pricing | capitalize }} &middot; {{ tool.status | capitalize }}</p>
-  <p class="tool-hero__description">{{ tool.description }}</p>
-  <div class="tool-actions">
-    <a class="btn btn-primary" href="{{ tool.links.homepage }}" rel="nofollow">Visit website</a>
-    {% if tool.links.pricing %}<a class="btn btn-secondary" href="{{ tool.links.pricing }}" rel="nofollow">View pricing</a>{% endif %}
-    {% if tool.links.docs %}<a class="btn btn-secondary" href="{{ tool.links.docs }}" rel="nofollow">Docs</a>{% endif %}
-  </div>
-</header>
+<div class="container">
+  <nav class="breadcrumb"><a href="/">Home</a> / <a href="/category/{{ primaryCategory }}/">{{ primaryCategory | replace('-', ' ') | title }}</a> / {{ tool.name }}</nav>
+  <header class="tool-hero">
+    <div class="tool-hero__badge">{{ tool.pricing | capitalize }} • {{ tool.adultLevel }}</div>
+    <h1>{{ tool.name }}</h1>
+    <p class="tool-hero__vendor">By {{ tool.vendor }} &middot; {{ tool.status | capitalize }}</p>
+    <p class="tool-hero__description">{{ tool.description }}</p>
+    <div class="tool-actions">
+      <a class="btn btn-primary" href="{{ tool.links.homepage }}" rel="nofollow">Visit website</a>
+      {% if tool.links.pricing %}<a class="btn btn-secondary" href="{{ tool.links.pricing }}" rel="nofollow">View pricing</a>{% endif %}
+      {% if tool.links.docs %}<a class="btn btn-secondary" href="{{ tool.links.docs }}" rel="nofollow">Docs</a>{% endif %}
+    </div>
+  </header>
 
-<section class="tool-details">
-  <div class="tool-panel">
-    <h2>Snapshot</h2>
-    <dl class="tool-meta">
-      <dt>Adult level</dt>
-      <dd>{{ tool.adultLevel }}</dd>
-      <dt>Pricing</dt>
-      <dd>{{ tool.pricing | capitalize }}</dd>
-      <dt>Regions</dt>
-      <dd>{{ tool.regions | join(', ') }}</dd>
-      <dt>Status</dt>
-      <dd>{{ tool.status | capitalize }}</dd>
-      <dt>Updated</dt>
-      <dd>{{ tool.updatedAt }}</dd>
-    </dl>
-  </div>
-  <div class="tool-panel">
-    <h2>Features</h2>
-    <ul>
-      {% for feature in tool.features %}
-      <li>{{ feature }}</li>
-      {% endfor %}
-    </ul>
-    {% if tool.tags | length %}
-    <h3>Tags</h3>
-    <ul class="pill-list">
-      {% for tag in tool.tags %}
-      <li class="pill">{{ tag }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-  </div>
-  <div class="tool-panel">
-    <h2>Compliance & Safety</h2>
-    {% if tool.compliance | length %}
-    <h3>Declared controls</h3>
-    <ul>
-      {% for item in tool.compliance %}
-      <li>{{ item }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    {% if tool.safetyNotes | length %}
-    <h3>Notes</h3>
-    <ul>
-      {% for note in tool.safetyNotes %}
-      <li>{{ note }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    {% if tool.affiliate %}
-    <h3>Affiliate program</h3>
-    <dl class="tool-meta">
-      {% if tool.affiliate.program %}<dt>Program</dt><dd>{{ tool.affiliate.program }}</dd>{% endif %}
-      {% if tool.affiliate.terms %}<dt>Terms</dt><dd>{{ tool.affiliate.terms }}</dd>{% endif %}
-      {% if tool.affiliate.payout %}<dt>Payout</dt><dd>{{ tool.affiliate.payout }}</dd>{% endif %}
-      {% if tool.affiliate.cookieDays %}<dt>Cookie</dt><dd>{{ tool.affiliate.cookieDays }} days</dd>{% endif %}
-    </dl>
-    {% endif %}
-  </div>
-</section>
+  <section class="tool-details">
+    <div class="tool-panel">
+      <h2>Snapshot</h2>
+      <dl class="tool-meta">
+        <dt>Adult level</dt>
+        <dd>{{ tool.adultLevel }}</dd>
+        <dt>Pricing</dt>
+        <dd>{{ tool.pricing | capitalize }}</dd>
+        <dt>Regions</dt>
+        <dd>{{ tool.regions | join(', ') }}</dd>
+        <dt>Status</dt>
+        <dd>{{ tool.status | capitalize }}</dd>
+        <dt>Updated</dt>
+        <dd>{{ tool.updatedAt }}</dd>
+      </dl>
+    </div>
+    <div class="tool-panel">
+      <h2>Features</h2>
+      <ul>
+        {% for feature in tool.features %}
+        <li>{{ feature }}</li>
+        {% endfor %}
+      </ul>
+      {% if tool.tags | length %}
+      <h3>Tags</h3>
+      <ul class="pill-list">
+        {% for tag in tool.tags %}
+        <li class="pill">{{ tag }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    <div class="tool-panel">
+      <h2>Compliance & Safety</h2>
+      {% if tool.compliance | length %}
+      <h3>Declared controls</h3>
+      <ul>
+        {% for item in tool.compliance %}
+        <li>{{ item }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% if tool.safetyNotes | length %}
+      <h3>Notes</h3>
+      <ul>
+        {% for note in tool.safetyNotes %}
+        <li>{{ note }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% if tool.affiliate %}
+      <h3>Affiliate program</h3>
+      <dl class="tool-meta">
+        {% if tool.affiliate.program %}<dt>Program</dt><dd>{{ tool.affiliate.program }}</dd>{% endif %}
+        {% if tool.affiliate.terms %}<dt>Terms</dt><dd>{{ tool.affiliate.terms }}</dd>{% endif %}
+        {% if tool.affiliate.payout %}<dt>Payout</dt><dd>{{ tool.affiliate.payout }}</dd>{% endif %}
+        {% if tool.affiliate.cookieDays %}<dt>Cookie</dt><dd>{{ tool.affiliate.cookieDays }} days</dd>{% endif %}
+      </dl>
+      {% endif %}
+    </div>
+  </section>
 
-{% if alternatives | length %}
-<section class="alternatives">
-  <h2>Alternatives worth exploring</h2>
-  <div class="tool-grid">
-    {% for alt in alternatives %}
-    <article class="tool-card">
-      <h3><a href="/tool/{{ alt.slug }}/">{{ alt.name }}</a></h3>
-      <p class="tool-card__meta">{{ alt.vendor }} &middot; {{ alt.pricing | capitalize }}</p>
-      <p class="tool-card__description">{{ alt.description | truncate(160, true, '…') }}</p>
-    </article>
-    {% endfor %}
-  </div>
-</section>
-{% endif %}
+  {% if alternatives | length %}
+  <section class="alternatives">
+    <h2>Alternatives worth exploring</h2>
+    <div class="tool-grid">
+      {% for alt in alternatives %}
+      <article class="tool-card">
+        <div class="tool-card__heading">
+          <h3><a href="/tool/{{ alt.slug }}/">{{ alt.name }}</a></h3>
+          <span class="tool-card__category">{{ alt.pricing | capitalize }}</span>
+        </div>
+        <p class="tool-card__meta">{{ alt.vendor }}</p>
+        <p class="tool-card__description">{{ alt.description | truncate(160, true, '…') }}</p>
+      </article>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redesign the directory layout with a modern hero, stats, and polished tool card styling
- wrap page templates in container/prose utilities to match the new site main layout
- copy CSS and JS source folders during builds so static assets ship with the site

## Testing
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ebfc02c883318cd177c4ff2b9bfa