### PR TITLE
Ensure age gate confirm button responds to iOS taps

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -139,6 +139,7 @@ a:focus {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   border: none;
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 .btn:hover {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -21,12 +21,51 @@ function initAgeGate() {
     return;
   }
   modal.hidden = false;
+  modal.setAttribute('aria-hidden', 'false');
   const enterButton = document.getElementById('age-gate-enter');
+  const form = document.getElementById('age-gate-form');
+  let hasConfirmed = false;
+
+  const confirmEntry = () => {
+    if (hasConfirmed) return;
+    hasConfirmed = true;
+    setCookie(AGE_COOKIE_NAME, '1', AGE_COOKIE_DAYS);
+    modal.hidden = true;
+    modal.setAttribute('aria-hidden', 'true');
+  };
+
+  const handleActivation = (event) => {
+    if (hasConfirmed) return;
+    if (event) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+    }
+    confirmEntry();
+  };
+
+  if (form) {
+    form.addEventListener('submit', handleActivation);
+  }
+
   if (enterButton) {
-    enterButton.addEventListener('click', () => {
-      setCookie(AGE_COOKIE_NAME, '1', AGE_COOKIE_DAYS);
-      modal.hidden = true;
+    enterButton.addEventListener('click', handleActivation);
+    enterButton.addEventListener(
+      'pointerup',
+      (event) => {
+        if (event.pointerType === 'touch') {
+          handleActivation(event);
+        }
+      },
+      { passive: false },
+    );
+    enterButton.addEventListener('touchend', handleActivation, { passive: false });
+    enterButton.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        confirmEntry();
+      }
     });
+    enterButton.focus();
   }
 }
 

--- a/src/templates/_layout.njk
+++ b/src/templates/_layout.njk
@@ -34,16 +34,16 @@
     </div>
   </header>
 
-  <div id="age-gate" class="age-gate" hidden>
-    <div class="age-gate__dialog" role="dialog" aria-modal="true" aria-labelledby="age-gate-title">
+  <div id="age-gate" class="age-gate" hidden aria-hidden="true">
+    <form id="age-gate-form" class="age-gate__dialog" role="dialog" aria-modal="true" aria-labelledby="age-gate-title" novalidate>
       <h2 id="age-gate-title">Adults only</h2>
       <p>This resource is intended for audiences aged 18 years or older. By entering you confirm you are at least 18 and agree to view explicit AI content responsibly.</p>
       <div class="age-gate__actions">
-        <button id="age-gate-enter" class="btn btn-primary">I am 18+</button>
+        <button id="age-gate-enter" class="btn btn-primary" type="submit">I am 18+</button>
         <a class="btn btn-secondary" href="https://google.com" rel="nofollow">Take me away</a>
       </div>
       <p class="age-gate__legal">We use a cookie to remember your choice for 30 days.</p>
-    </div>
+    </form>
   </div>
 
   <main id="main" class="site-main">


### PR DESCRIPTION
## Summary
- guard the age gate activation handler against repeat taps and stop propagation of handled events
- add a touchend listener so the confirm button responds on browsers that do not emit pointer events

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ef403cd483319ed8899035a5a41f