### PR TITLE
Remove age gate overlay

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -573,33 +573,6 @@ a:focus {
   gap: 1.1rem;
 }
 
-.age-gate {
-  position: fixed;
-  inset: 0;
-  background: rgba(4, 4, 12, 0.92);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 999;
-}
-
-.age-gate__dialog {
-  background: rgba(8, 8, 18, 0.95);
-  border: 1px solid var(--accent);
-  padding: 2rem;
-  border-radius: 1rem;
-  max-width: 420px;
-  text-align: center;
-  box-shadow: 0 28px 60px rgba(4, 4, 16, 0.6);
-}
-
-.age-gate__actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  margin: 1.5rem 0;
-}
-
 .prose {
   max-width: 780px;
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,39 +1,5 @@
 import { createSearch } from './search.js';
 
-const AGE_COOKIE_NAME = 'aipd_age_verified';
-const AGE_COOKIE_DAYS = 30;
-
-function setCookie(name, value, days) {
-  const expires = new Date(Date.now() + days * 864e5).toUTCString();
-  document.cookie = `${name}=${value}; expires=${expires}; path=/; SameSite=Lax`;
-}
-
-function getCookie(name) {
-  return document.cookie.split('; ').find((row) => row.startsWith(name + '='))?.split('=')[1];
-}
-
-function initAgeGate() {
-  const isBot = /bot|crawl|spider|slurp|duckduck|bingpreview/i.test(navigator.userAgent);
-  if (isBot) return;
-  const modal = document.getElementById('age-gate');
-  if (!modal) return;
-  if (getCookie(AGE_COOKIE_NAME) === '1') {
-    return;
-  }
-  modal.hidden = false;
-  const enterButton = document.getElementById('age-gate-enter');
-  if (enterButton) {
-    const confirmEntry = (event) => {
-      event.preventDefault();
-      setCookie(AGE_COOKIE_NAME, '1', AGE_COOKIE_DAYS);
-      modal.hidden = true;
-    };
-    enterButton.addEventListener('click', confirmEntry, { passive: false });
-    enterButton.addEventListener('touchend', confirmEntry, { passive: false });
-    enterButton.focus();
-  }
-}
-
 function applyFilters({ cards, slugs, category }) {
   cards.forEach((card) => {
     const cardCategories = JSON.parse(card.dataset.categories || '[]');
@@ -82,6 +48,5 @@ async function initDirectoryUI() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  initAgeGate();
   initDirectoryUI();
 });

--- a/src/templates/_layout.njk
+++ b/src/templates/_layout.njk
@@ -34,18 +34,6 @@
     </div>
   </header>
 
-  <div id="age-gate" class="age-gate" hidden>
-    <div class="age-gate__dialog" role="dialog" aria-modal="true" aria-labelledby="age-gate-title">
-      <h2 id="age-gate-title">Adults only</h2>
-      <p>This resource is intended for audiences aged 18 years or older. By entering you confirm you are at least 18 and agree to view explicit AI content responsibly.</p>
-      <div class="age-gate__actions">
-        <button id="age-gate-enter" class="btn btn-primary" type="button">I am 18+</button>
-        <a class="btn btn-secondary" href="https://google.com" rel="nofollow">Take me away</a>
-      </div>
-      <p class="age-gate__legal">We use a cookie to remember your choice for 30 days.</p>
-    </div>
-  </div>
-
   <main id="main" class="site-main">
     {% block content %}{% endblock %}
   </main>


### PR DESCRIPTION
## Summary
- remove the age gate overlay markup from the layout template
- drop associated styles and JavaScript helpers now that the age gate is gone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fc824a048331aed3529f0634d393