### PR TITLE
Fix site card overlay blocking interactions

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -417,6 +417,7 @@ a:focus {
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
+  pointer-events: none;
 }
 
 .site-card:hover {


### PR DESCRIPTION
## Summary
- allow the gradient border overlay on site cards to ignore pointer events so card links remain interactive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6435293a88331b0ca53b9d5771bc2