### PR TITLE
Ensure affiliate links render without HTML escaping

### DIFF
--- a/src/data/sites.json
+++ b/src/data/sites.json
@@ -4,7 +4,7 @@
       "id": "candy-ai",
       "slug": "candy-ai",
       "name": "Candy AI",
-      "website": "https://candy.ai/",
+      "website": "https://t.mbsrv2.com/366307/6646?popUnder=true&aff_sub5=SF_006OG000004lmDN",
       "rank": 1,
       "categories": [
         "chatbot"

--- a/src/templates/category.njk
+++ b/src/templates/category.njk
@@ -40,7 +40,7 @@
           </ul>
           <div class="site-card__actions">
             <a class="btn btn-secondary" href="/site/{{ site.slug }}/">Profile</a>
-            <a class="btn btn-primary" href="{{ site.website }}" rel="noopener" target="_blank">Visit →</a>
+            <a class="btn btn-primary" href="{{ site.website | safe }}" rel="noopener" target="_blank">Visit →</a>
           </div>
         </div>
       </article>

--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -92,7 +92,7 @@
           </ul>
           <div class="site-card__actions">
             <a class="btn btn-secondary" href="/site/{{ site.slug }}/">Profile</a>
-            <a class="btn btn-primary" href="{{ site.website }}" rel="noopener" target="_blank">Visit →</a>
+            <a class="btn btn-primary" href="{{ site.website | safe }}" rel="noopener" target="_blank">Visit →</a>
           </div>
         </div>
       </article>

--- a/src/templates/site.njk
+++ b/src/templates/site.njk
@@ -22,7 +22,7 @@
       {% if site.source %}<span>Source: {{ site.source | title }}</span>{% endif %}
     </div>
     <div class="site-actions">
-      <a class="btn btn-primary" href="{{ site.website }}" rel="noopener" target="_blank">Visit website</a>
+      <a class="btn btn-primary" href="{{ site.website | safe }}" rel="noopener" target="_blank">Visit website</a>
       <a class="btn btn-secondary" href="mailto:submit@aiporndirect.com?subject=Update {{ site.name }}">Suggest an edit</a>
     </div>
   </header>
@@ -93,7 +93,7 @@
           </ul>
           <div class="site-card__actions">
             <a class="btn btn-secondary" href="/site/{{ alt.slug }}/">Profile</a>
-            <a class="btn btn-primary" href="{{ alt.website }}" rel="noopener" target="_blank">Visit →</a>
+            <a class="btn btn-primary" href="{{ alt.website | safe }}" rel="noopener" target="_blank">Visit →</a>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- render CTA links using the raw site.website URL so affiliate query parameters remain intact
- update the site, category, and directory templates to mark site.website as safe

## Testing
- npm run validate
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6530bf50883319eb47edc8172989d