### PR TITLE
Update GirlfriendGPT referral link

### DIFF
--- a/src/data/sites.json
+++ b/src/data/sites.json
@@ -62,7 +62,7 @@
       "id": "girlfriendgpt",
       "slug": "girlfriendgpt",
       "name": "GirlfriendGPT",
-      "website": "https://girlfriendgpt.com/",
+      "website": "https://www.gptgirlfriend.online/?ref=owqymzq",
       "rank": 3,
       "categories": [
         "chatbot"


### PR DESCRIPTION
## Summary
- update the GirlfriendGPT listing to point at the new gptgirlfriend.online referral URL

## Testing
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68d69e69ca0483318bb136e5a0db0805