### PR TITLE
Improve SEO metadata and add working sorting UI

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -190,6 +190,20 @@ a:focus {
   z-index: 1;
 }
 
+.hero__title {
+  margin: 0 0 1.2rem;
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+}
+
+.hero__description {
+  margin: 0 0 1.8rem;
+  color: var(--muted);
+  font-size: 1rem;
+  max-width: 58ch;
+}
+
 .hero__eyebrow {
   display: inline-flex;
   align-items: center;
@@ -360,6 +374,58 @@ a:focus {
 
 .section-link:hover {
   color: var(--accent);
+}
+
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.sort-control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.sort-control__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.sort-control__select {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding-right: 1.8rem;
+  cursor: pointer;
+}
+
+.sort-control__select:focus {
+  outline: none;
+}
+
+.sort-control::after {
+  content: '▾';
+  position: absolute;
+  right: 0.8rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  font-size: 0.8rem;
+  pointer-events: none;
 }
 
 .section-title {
@@ -763,6 +829,11 @@ a:focus {
   .site-details {
     grid-template-columns: 1fr;
   }
+
+  .section-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 @media (max-width: 540px) {
@@ -777,6 +848,26 @@ a:focus {
   .section-heading {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .section-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .sort-control {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .sort-control__select {
+    width: 100%;
+  }
+
+  .section-link {
+    align-self: flex-start;
   }
 
   .site-actions {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,67 @@
 import { createSearch } from './search.js';
 
+function toNumber(value, fallback = 0) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function toTimestamp(value, fallback = 0) {
+  if (!value) return fallback;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? time : fallback;
+}
+
+function getCardName(card) {
+  const datasetName = card.dataset.name || '';
+  if (datasetName.trim()) {
+    return datasetName.trim().toLowerCase();
+  }
+  const heading = card.querySelector('h3, h2');
+  return heading ? heading.textContent.trim().toLowerCase() : '';
+}
+
+function compareCards(a, b, sortKey) {
+  const nameA = getCardName(a);
+  const nameB = getCardName(b);
+
+  switch (sortKey) {
+    case 'rating': {
+      const ratingDiff = toNumber(b.dataset.rating, -Infinity) - toNumber(a.dataset.rating, -Infinity);
+      if (ratingDiff !== 0) return ratingDiff;
+      const voteDiff = toNumber(b.dataset.votes, 0) - toNumber(a.dataset.votes, 0);
+      if (voteDiff !== 0) return voteDiff;
+      return nameA.localeCompare(nameB);
+    }
+    case 'votes': {
+      const voteDiff = toNumber(b.dataset.votes, 0) - toNumber(a.dataset.votes, 0);
+      if (voteDiff !== 0) return voteDiff;
+      const ratingDiff = toNumber(b.dataset.rating, -Infinity) - toNumber(a.dataset.rating, -Infinity);
+      if (ratingDiff !== 0) return ratingDiff;
+      return nameA.localeCompare(nameB);
+    }
+    case 'alphabetical':
+      return nameA.localeCompare(nameB);
+    case 'recent': {
+      const recentDiff = toTimestamp(b.dataset.lastChecked) - toTimestamp(a.dataset.lastChecked);
+      if (recentDiff !== 0) return recentDiff;
+      return nameA.localeCompare(nameB);
+    }
+    case 'rank':
+    default: {
+      const rankDiff = toNumber(a.dataset.rank, Number.POSITIVE_INFINITY) - toNumber(b.dataset.rank, Number.POSITIVE_INFINITY);
+      if (rankDiff !== 0) return rankDiff;
+      return nameA.localeCompare(nameB);
+    }
+  }
+}
+
+function sortCards(cards, sortKey) {
+  return [...cards].sort((a, b) => compareCards(a, b, sortKey));
+}
+
 function applyFilters({ cards, slugs, category }) {
   cards.forEach((card) => {
     const cardCategories = JSON.parse(card.dataset.categories || '[]');
@@ -19,12 +81,24 @@ async function initDirectoryUI() {
   const cards = Array.from(document.querySelectorAll('.site-card'));
   if (!cards.length) return;
   const categoryButtons = Array.from(document.querySelectorAll('#category-filter .filter-chip'));
+  const grid = document.getElementById('site-grid');
+  const sortSelect = document.getElementById('sort-order');
   let currentCategory = 'all';
   let currentSlugs = new Set(cards.map((card) => card.dataset.slug));
+  let currentSort = (sortSelect && sortSelect.value) || 'rank';
   const search = await createSearch();
+
+  function reorderCards() {
+    if (!grid) return;
+    const sortedCards = sortCards(cards, currentSort);
+    sortedCards.forEach((card) => {
+      grid.appendChild(card);
+    });
+  }
 
   function updateUI() {
     applyFilters({ cards, slugs: currentSlugs, category: currentCategory });
+    reorderCards();
   }
 
   categoryButtons.forEach((button) => {
@@ -40,6 +114,13 @@ async function initDirectoryUI() {
       const value = event.target.value || '';
       const results = await search(value);
       currentSlugs = new Set(results);
+      updateUI();
+    });
+  }
+
+  if (sortSelect) {
+    sortSelect.addEventListener('change', (event) => {
+      currentSort = event.target.value;
       updateUI();
     });
   }

--- a/src/templates/_layout.njk
+++ b/src/templates/_layout.njk
@@ -4,15 +4,32 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="index,follow">
-  <title>{{ title | default('AiPornDirect') }}</title>
-  <meta name="description" content="{{ description | default('Independent index of AI porn sites with filters, highlights, and safety context mirrored from The Porn Dude.') }}">
-
+  {% set pageTitle = title | default('Best Adult AI Porn Sites Directory | AiPornDirect') %}
+  {% set pageDescription = description | default('AiPornDirect curates the best adult AI porn sites, NSFW chatbots, erotic AI generators, and deepfake tools with reviews, pricing, and safety notes.') %}
+  {% set pageKeywords = keywords | default('AI porn, AI porn sites, adult AI tools, NSFW AI generators, AI girlfriends, deepfake AI directory, porn AI, erotic AI') %}
+  {% set pageCanonical = canonical | default('https://aiporndirect.com/') %}
+  {% set openGraphType = ogType | default('website') %}
+  <title>{{ pageTitle }}</title>
+  <meta name="description" content="{{ pageDescription }}">
+  <meta name="keywords" content="{{ pageKeywords }}">
+  <meta name="author" content="AiPornDirect">
+  <meta name="theme-color" content="#050518">
+  <meta property="og:site_name" content="AiPornDirect">
+  <meta property="og:type" content="{{ openGraphType }}">
+  <meta property="og:title" content="{{ pageTitle }}">
+  <meta property="og:description" content="{{ pageDescription }}">
+  {% if pageCanonical %}
+  <meta property="og:url" content="{{ pageCanonical }}">
+  <link rel="canonical" href="{{ pageCanonical }}">
+  {% endif %}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ pageTitle }}">
+  <meta name="twitter:description" content="{{ pageDescription }}">
   <link rel="stylesheet" href="/css/styles.css">
   <link rel="icon" href="/icons/favicon.ico">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  {% if canonical %}<link rel="canonical" href="{{ canonical }}">{% endif %}
   {% block head %}{% endblock %}
 </head>
 <body class="{{ bodyClass | default('') }}">

--- a/src/templates/category.njk
+++ b/src/templates/category.njk
@@ -1,22 +1,43 @@
 {% extends "_layout.njk" %}
 {% block head %}
-<meta property="og:title" content="{{ title }}">
-<meta property="og:description" content="{{ description }}">
+{% if categoryLdjson %}
+<script type="application/ld+json">
+{{ categoryLdjson | dump(2) | safe }}
+</script>
+{% endif %}
 {% endblock %}
 {% block content %}
 <div class="container">
   <header class="page-header">
     <p class="breadcrumb"><a href="/">Home</a> / {{ category.name }}</p>
     <h1>{{ category.name }}</h1>
-    <p>{{ category.description }}</p>
+    <p>{{ description }}</p>
     {% if lastUpdated %}
     <p class="page-header__meta">Last verified {{ lastUpdated }}</p>
     {% endif %}
   </header>
   <section class="section section--category">
-    <div class="site-grid">
+    <div class="section-heading">
+      <div>
+        <h2 class="section-title">{{ category.name }} AI porn sites</h2>
+        <p class="section-subtitle">Sort curated listings of {{ category.name | lower }} tools, apps, and services.</p>
+      </div>
+      <div class="section-actions">
+        <div class="sort-control">
+          <label class="sort-control__label" for="sort-order">Sort by</label>
+          <select id="sort-order" class="sort-control__select">
+            <option value="rank">Editor ranking</option>
+            <option value="rating">Highest rating</option>
+            <option value="votes">Most votes</option>
+            <option value="alphabetical">A–Z</option>
+            <option value="recent">Recently verified</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="site-grid" id="site-grid">
       {% for site in sites %}
-      <article class="site-card site-card--compact">
+      <article class="site-card site-card--compact" data-slug="{{ site.slug }}" data-categories='{{ (site.categories or []) | dump }}' data-tags='{{ (site.tags or []) | dump }}' data-pricing="{{ site.pricing }}" data-rank="{{ site.rank or loop.index }}" data-rating="{{ site.rating if site.rating is not none else '' }}" data-votes="{{ site.votes if site.votes is not none else '' }}" data-name="{{ site.name }}" data-last-checked="{{ site.lastChecked or '' }}">
         <header class="site-card__header">
           <div class="site-card__meta">
             <span class="site-card__rank">#{{ site.rank or loop.index }}</span>

--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -1,12 +1,20 @@
 {% extends "_layout.njk" %}
 
+{% block head %}
+{% if directoryLdjson %}
+<script type="application/ld+json">
+{{ directoryLdjson | dump(2) | safe }}
+</script>
+{% endif %}
+{% endblock %}
+
 {% block content %}
 <section class="hero hero--directory">
   <div class="container">
     <div class="hero__surface">
       <div class="hero__content">
-
-        </p>
+        <h1 class="hero__title">Best Adult AI Porn Sites Directory</h1>
+        <p class="hero__description">AiPornDirect ranks the leading adult AI porn generators, NSFW chatbots, erotic companions, and deepfake makers with safety notes and pricing updated {{ lastUpdated or 'regularly' }}.</p>
         <ul class="hero__stats">
           <li>
             <span class="hero__stat-value">{{ sites | length }}</span>
@@ -51,14 +59,26 @@
     <div class="section-heading">
       <div>
         <h2 class="section-title">All AI porn sites</h2>
-
+        <p class="section-subtitle">Browse verified NSFW AI tools, adult chatbots, and porn generators by ranking, rating, or freshness.</p>
       </div>
-      <a class="section-link" href="mailto:submit@aiporndirect.com">Request an update →</a>
+      <div class="section-actions">
+        <div class="sort-control">
+          <label class="sort-control__label" for="sort-order">Sort by</label>
+          <select id="sort-order" class="sort-control__select">
+            <option value="rank">Editor ranking</option>
+            <option value="rating">Highest rating</option>
+            <option value="votes">Most votes</option>
+            <option value="alphabetical">A–Z</option>
+            <option value="recent">Recently verified</option>
+          </select>
+        </div>
+        <a class="section-link" href="mailto:submit@aiporndirect.com">Request an update →</a>
+      </div>
     </div>
     {% if sites | length %}
     <div class="site-grid" id="site-grid">
       {% for site in sites %}
-      <article class="site-card" data-slug="{{ site.slug }}" data-categories='{{ site.categories | dump }}' data-tags='{{ site.tags | dump }}' data-pricing="{{ site.pricing }}">
+      <article class="site-card" data-slug="{{ site.slug }}" data-categories='{{ (site.categories or []) | dump }}' data-tags='{{ (site.tags or []) | dump }}' data-pricing="{{ site.pricing }}" data-rank="{{ site.rank or loop.index }}" data-rating="{{ site.rating if site.rating is not none else '' }}" data-votes="{{ site.votes if site.votes is not none else '' }}" data-name="{{ site.name }}" data-last-checked="{{ site.lastChecked or '' }}">
         <header class="site-card__header">
           <div class="site-card__meta">
             <span class="site-card__rank">#{{ site.rank or loop.index }}</span>

--- a/src/templates/site.njk
+++ b/src/templates/site.njk
@@ -1,7 +1,5 @@
 {% extends "_layout.njk" %}
 {% block head %}
-<meta property="og:title" content="{{ site.name }} — AI porn site profile">
-<meta property="og:description" content="{{ site.summary | truncate(180, true, '…') }}">
 <script type="application/ld+json">
 {{ ldjson | dump(2) | safe }}
 </script>
@@ -73,7 +71,7 @@
     <h2>Similar AI porn sites</h2>
     <div class="site-grid">
       {% for alt in alternatives %}
-      <article class="site-card site-card--compact">
+      <article class="site-card site-card--compact" data-slug="{{ alt.slug }}" data-categories='{{ (alt.categories or []) | dump }}' data-tags='{{ (alt.tags or []) | dump }}' data-pricing="{{ alt.pricing }}" data-rank="{{ alt.rank or loop.index }}" data-rating="{{ alt.rating if alt.rating is not none else '' }}" data-votes="{{ alt.votes if alt.votes is not none else '' }}" data-name="{{ alt.name }}" data-last-checked="{{ alt.lastChecked or '' }}">
         <header class="site-card__header">
           <div class="site-card__meta">
             <span class="site-card__rank">#{{ alt.rank or loop.index }}</span>


### PR DESCRIPTION
## Summary
- expand base layout metadata with richer keywords, Open Graph, and Twitter tags for better SEO coverage
- add structured data payloads, hero copy, and keyword-rich descriptions across the directory and category templates
- implement a functional sorting control with supporting styles and client logic to reorder listings by rank, rating, votes, A–Z, or recent verification

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc663022748331893da7dc9748cfef